### PR TITLE
fix: populate Requests Over Time chart faster

### DIFF
--- a/generator.py
+++ b/generator.py
@@ -406,7 +406,7 @@ _WEB_STATE: dict = {
     "test_started_at": 0.0,
     "tests": {}, "suites": [],
     "totals": {"attempts": 0, "ok": 0, "fail": 0},
-    "history": [], "events": [],
+    "history": [{"t": int(__import__("time").time()), "ok": 0, "fail": 0}], "events": [],
     "_history_last_t": 0.0,
 }
 _WEB_STATE_LOCK  = threading.Lock()
@@ -478,12 +478,12 @@ def _web_record(name: str, ok: bool, dur_ms: int,
             _WEB_STATE["events"] = _WEB_STATE["events"][-100:]
 
         now = time.time()
-        if now - _WEB_STATE["_history_last_t"] >= 30:
+        if now - _WEB_STATE["_history_last_t"] >= 5:
             _WEB_STATE["history"].append(
                 {"t": int(now), "ok": tot["ok"], "fail": tot["fail"]}
             )
-            if len(_WEB_STATE["history"]) > 60:
-                _WEB_STATE["history"] = _WEB_STATE["history"][-60:]
+            if len(_WEB_STATE["history"]) > 120:
+                _WEB_STATE["history"] = _WEB_STATE["history"][-120:]
             _WEB_STATE["_history_last_t"] = now
 
         _web_flush()


### PR DESCRIPTION
## Summary

- History sample interval reduced from 30s → 5s, so the Requests Over Time chart populates within a few seconds of the first completed test instead of waiting a full minute for two data points
- History buffer increased from 60 → 120 samples to preserve ~10 minutes of history at the faster rate
- Seeded one data point at process start so the chart area is never blank on first page load

## Test plan

- [ ] Open the web dashboard immediately after starting the container — chart should show a data point within 5–10 seconds of the first test completing rather than sitting on "Accumulating data…" for 60+ seconds

https://claude.ai/code/session_01TzvcBrPJf7cnjnXSmQfkg1

---
_Generated by [Claude Code](https://claude.ai/code/session_01TzvcBrPJf7cnjnXSmQfkg1)_