### PR TITLE
fix: remove generator.py:NNN from Output tab; add sparkline hover tooltips

### DIFF
--- a/generator.py
+++ b/generator.py
@@ -106,6 +106,10 @@ class _DualWriter:
             return
         if self._baronly.match(line):
             return
+        # Strip Rich console.log() auto-appended filename:lineno suffix
+        line = re.sub(r'\s{2,}\S+\.py:\d+\s*$', '', line).rstrip()
+        if not line:
+            return
         # Classify
         if line[0] in '╭╰│╔╚║├':
             lvl = 'banner'
@@ -123,7 +127,7 @@ class _DualWriter:
 
 
 _dual_writer = _DualWriter()
-console = Console(highlight=False, file=_dual_writer)
+console = Console(highlight=False, log_path=False, file=_dual_writer)
 
 # Suppress SSL warnings — this tool intentionally hits self-signed / expired certs.
 urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)

--- a/webui.py
+++ b/webui.py
@@ -656,6 +656,7 @@ html.light .obody .ll:hover{background:rgba(0,0,0,.04)}html.light .cmd-blk{backg
 .net-dir{display:flex;flex-direction:column;gap:1px}
 .net-lbl{font-size:9px;font-weight:600;letter-spacing:.6px;text-transform:uppercase;color:var(--muted)}
 .net-val{font-size:15px;font-weight:700}
+.tt{position:fixed;pointer-events:none;display:none;background:var(--surf2);border:1px solid var(--border2);border-radius:5px;padding:5px 9px;font-size:11px;font-family:'SF Mono',Consolas,monospace;line-height:1.8;z-index:200;color:var(--text);white-space:nowrap;box-shadow:0 2px 8px rgba(0,0,0,.4)}
 </style>
 </head>
 <body>
@@ -1275,6 +1276,46 @@ window.addEventListener('resize',()=>{
   if(_lastState)drawSpark(_lastState.history||[]);
   if(_lastHealth){drawDiskBars(_lastHealth.disk_read_kbps||0,_lastHealth.disk_write_kbps||0);drawNetSpark('net-spark',_netHist);drawNetSpark('h-net-spark',_hNetHist);}
 });
+// ── Canvas hover tooltips ──────────────────────────────────────────────────
+const _tt=document.createElement('div');_tt.className='tt';document.body.appendChild(_tt);
+function showTip(e,lines){
+  _tt.innerHTML=lines.filter(Boolean).join('<br>');_tt.style.display='block';
+  const r=_tt.getBoundingClientRect();
+  let x=e.clientX+14,y=e.clientY-r.height/2;
+  if(x+r.width>window.innerWidth-4)x=e.clientX-r.width-10;
+  if(y<4)y=4;if(y+r.height>window.innerHeight-4)y=window.innerHeight-r.height-4;
+  _tt.style.left=x+'px';_tt.style.top=y+'px';
+}
+function hideTip(){_tt.style.display='none';}
+function wireTip(cid,pl,pr,getHist,fmt){
+  const c=$(cid);if(!c)return;
+  c.style.cursor='crosshair';
+  c.addEventListener('mousemove',e=>{
+    const h=getHist();if(!h||h.length<2)return;
+    const rect=c.getBoundingClientRect();
+    const IW=rect.width-pl-pr;
+    const xi=e.clientX-rect.left-pl;
+    let i=Math.round(xi/IW*(h.length-1));
+    i=Math.max(0,Math.min(h.length-1,i));
+    showTip(e,fmt(h[i]));
+  });
+  c.addEventListener('mouseleave',hideTip);
+}
+wireTip('spark',36,10,()=>(_lastState&&_lastState.history)||[],p=>[
+  `<span style="color:var(--muted)">${Tc(p.t)}</span>`,
+  `<span style="color:var(--green)">✔ OK&nbsp;&nbsp;&nbsp;${N(p.ok)}</span>`,
+  p.fail?`<span style="color:var(--red)">✗ Fail&nbsp;&nbsp;${N(p.fail)}</span>`:''
+]);
+wireTip('net-spark',10,6,()=>_netHist,p=>[
+  `<span style="color:var(--muted)">${Tc(p.t)}</span>`,
+  `<span style="color:var(--green)">▼ RX&nbsp;&nbsp;${fmtIO(p.rx||0)}</span>`,
+  `<span style="color:var(--blue)">▲ TX&nbsp;&nbsp;${fmtIO(p.tx||0)}</span>`
+]);
+wireTip('h-net-spark',10,6,()=>_hNetHist,p=>[
+  `<span style="color:var(--muted)">${Tc(p.t)}</span>`,
+  `<span style="color:var(--green)">▼ RX&nbsp;&nbsp;${fmtIO(p.rx||0)}</span>`,
+  `<span style="color:var(--blue)">▲ TX&nbsp;&nbsp;${fmtIO(p.tx||0)}</span>`
+]);
 connect();
 </script>
 </body></html>"""


### PR DESCRIPTION
## Summary

- **`generator.py:NNN` removed from Output tab**: `Console(log_path=False)` suppresses Rich's auto-appended `[filename:lineno]` on every `console.log()` call. A regex strip in `_DualWriter._flush_line()` catches any remaining occurrences from tracebacks or other sources.

- **Hover tooltips on sparklines**: `wireTip()` wires `mousemove`/`mouseleave` to each canvas, maps the mouse x position to the nearest data point, and shows a floating tooltip. Cursor changes to crosshair on hover.
  - **Requests Over Time** → timestamp · OK count · Fail count
  - **Overview Network I/O** → timestamp · RX · TX
  - **Health Network I/O** → timestamp · RX · TX
  - Tooltip auto-flips left when near the right edge of the viewport.

## Test plan

- [ ] Open Output tab — confirm no `generator.py:NNN` suffix appears on log lines
- [ ] Hover over Requests Over Time sparkline — tooltip shows time/ok/fail at that point
- [ ] Hover over Overview Network I/O sparkline — tooltip shows RX/TX
- [ ] Switch to Health tab, hover over Network I/O sparkline — tooltip shows RX/TX
- [ ] Hover near right edge of viewport — tooltip flips to left of cursor

https://claude.ai/code/session_01TzvcBrPJf7cnjnXSmQfkg1

---
_Generated by [Claude Code](https://claude.ai/code/session_01TzvcBrPJf7cnjnXSmQfkg1)_