### PR TITLE
chore: change default size from XS to S everywhere

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -176,4 +176,4 @@ RUN rm -rf \
 EXPOSE 7777
 
 ENTRYPOINT ["/traffgen/docker-entrypoint.sh"]
-CMD ["--suite=all", "--size=XS", "--max-wait-secs=20", "--loop"]
+CMD ["--suite=all", "--size=S", "--max-wait-secs=20", "--loop"]

--- a/README.md
+++ b/README.md
@@ -22,11 +22,11 @@ docker run --pull=always -it jdibby/traffgen:latest --help
 # Run all suites in a continuous loop (background daemon)
 docker run --pull=always --detach --restart unless-stopped \
   --name traffgen jdibby/traffgen:latest \
-  --suite=all --size=XS --max-wait-secs=20 --loop
+  --suite=all --size=S --max-wait-secs=20 --loop
 
 # Run all suites interactively
 docker run --pull=always --restart unless-stopped -it \
-  jdibby/traffgen:latest --suite=all --size=XS --max-wait-secs=20 --loop
+  jdibby/traffgen:latest --suite=all --size=S --max-wait-secs=20 --loop
 
 # Run a single suite once
 docker run --pull=always -it jdibby/traffgen:latest --suite=nmap --size=L
@@ -53,7 +53,7 @@ Add `-p 7777:7777` to expose a live HTTPS monitoring dashboard at `https://<host
 ```bash
 docker run --pull=always --detach --restart unless-stopped \
   -p 7777:7777 --name traffgen jdibby/traffgen:latest \
-  --suite=all --size=XS --max-wait-secs=20 --loop
+  --suite=all --size=S --max-wait-secs=20 --loop
 ```
 
 The dashboard includes:
@@ -74,7 +74,7 @@ The dashboard includes:
 | Flag | Values | Default | Description |
 |---|---|---|---|
 | `--suite` | See suite names below | `all` | Test suite to run |
-| `--size` | `XS` `S` `M` `L` `XL` | `XS` | Traffic volume / intensity |
+| `--size` | `XS` `S` `M` `L` `XL` | `S` | Traffic volume / intensity |
 | `--loop` | — | off | Loop forever, picking tests at random each iteration |
 | `--max-wait-secs` | integer | `20` | Max random pause between iterations when looping |
 | `--nowait` | — | off | Disable all inter-test pauses (loop and single-run mode) |
@@ -260,7 +260,7 @@ Three-stage multi-arch build (`linux/amd64`, `linux/arm64`, `linux/arm/v7`):
 
 **❤️ Healthcheck:** `healthcheck.sh` uses `pgrep` to verify `generator.py` is running. Evaluated every 10 seconds with a 3-second timeout and 2 retries.
 
-**🚀 Entrypoint:** `docker-entrypoint.sh` auto-detects TLS-inspection proxies, installs any injected CA certificates, then launches `python3 -u /traffgen/generator.py`. Default `CMD` is `--suite=all --size=XS --max-wait-secs=20 --loop`.
+**🚀 Entrypoint:** `docker-entrypoint.sh` auto-detects TLS-inspection proxies, installs any injected CA certificates, then launches `python3 -u /traffgen/generator.py`. Default `CMD` is `--suite=all --size=S --max-wait-secs=20 --loop`.
 
 **📊 Suite Summary:** After every suite completes, a summary panel is printed to the CLI — see [Suite Summary](#-suite-summary) below.
 
@@ -315,7 +315,7 @@ Export your proxy's CA as a PEM file and mount it into the container:
 docker run --pull=always --detach --restart unless-stopped \
   -v /path/to/proxy-ca.crt:/usr/local/share/ca-certificates/proxy-ca.crt \
   --name traffgen jdibby/traffgen:latest \
-  --suite=all --size=XS --max-wait-secs=20 --loop
+  --suite=all --size=S --max-wait-secs=20 --loop
 ```
 
 ### Option 2 — Inline PEM via environment variable
@@ -326,7 +326,7 @@ Useful for Kubernetes secrets, Docker Swarm configs, or CI pipelines:
 docker run --pull=always --detach --restart unless-stopped \
   -e EXTRA_CA_CERT="$(cat /path/to/proxy-ca.crt)" \
   --name traffgen jdibby/traffgen:latest \
-  --suite=all --size=XS --max-wait-secs=20 --loop
+  --suite=all --size=S --max-wait-secs=20 --loop
 ```
 
 Options 1 and 2 are installed first; the auto-probe (Option 3) runs after, so if a manually-supplied cert already covers the proxy the probe will see a clean chain and skip.  All options can be combined, and multiple `.crt` files can be mounted simultaneously.
@@ -464,7 +464,7 @@ traffgen includes a built-in HTTPS monitoring dashboard on **port 7777**. No con
 # Run with port 7777 exposed
 docker run --pull=always --detach --restart unless-stopped \
   -p 7777:7777 jdibby/traffgen:latest \
-  --suite=all --size=XS --max-wait-secs=20 --loop
+  --suite=all --size=S --max-wait-secs=20 --loop
 
 # Open in browser (accept the self-signed certificate warning)
 https://<host-ip>:7777

--- a/docs/web-dashboard.md
+++ b/docs/web-dashboard.md
@@ -18,7 +18,7 @@ Add `-p 7777:7777` to your `docker run` command:
 docker run --pull=always --detach --restart unless-stopped \
   -p 7777:7777 \
   --name traffgen jdibby/traffgen:latest \
-  --suite=all --size=XS --max-wait-secs=20 --loop
+  --suite=all --size=S --max-wait-secs=20 --loop
 ```
 
 If deployed via `stager.sh`, port 7777 is opened automatically and the dashboard URL is printed at the end of installation.
@@ -31,7 +31,7 @@ The dashboard has a **dark sidebar** on the left with navigation, and a main con
 
 ```
 ┌─────────────────┬──────────────────────────────────────────────────────────┐
-│  🚦 traffgen    │  [Page Title]   suite:all  size:XS  ● Running            │
+│  🚦 traffgen    │  [Page Title]   suite:all  size:S  ● Running            │
 │                 │                                       ⏸  ⏹  ⚙  ☾  LIVE │
 │  MONITOR        ├──────────────────────────────────────────────────────────┤
 │  ◈ Overview     │                                                          │

--- a/generator.py
+++ b/generator.py
@@ -404,7 +404,7 @@ _WEB_PAUSE_FILE  = "/tmp/traffgen_pause"
 _WEB_STOP_FILE   = "/tmp/traffgen_stop"
 
 _WEB_STATE: dict = {
-    "version": "", "started_at": 0.0, "suite": "all", "size": "XS",
+    "version": "", "started_at": 0.0, "suite": "all", "size": "S",
     "max_wait_secs": 20, "loop": True, "current_test": "", "iteration": 0,
     "status": "starting",   # running | between_tests | paused | stopped
     "test_started_at": 0.0,
@@ -527,9 +527,9 @@ def _argv_from_cmd(cmd: dict) -> list:
     if suite not in valid_suites:
         suite = "all"
 
-    size = str(cmd.get("size", "XS"))
+    size = str(cmd.get("size", "S"))
     if size not in valid_sizes:
-        size = "XS"
+        size = "S"
 
     try:
         wait = max(5, min(300, int(cmd.get("max_wait_secs", 20))))

--- a/stager.sh
+++ b/stager.sh
@@ -224,7 +224,7 @@ docker run \
     -p 7777:7777 \
     --name traffgen \
     jdibby/traffgen:latest \
-    --suite=all --size=XS --max-wait-secs=20 --loop
+    --suite=all --size=S --max-wait-secs=20 --loop
 
 ok "Container started"
 

--- a/webui.py
+++ b/webui.py
@@ -234,7 +234,7 @@ def _read_state() -> dict:
     except Exception:
         return {
             "version": "—", "started_at": time.time(), "suite": "all",
-            "size": "XS", "loop": True, "max_wait_secs": 20,
+            "size": "S", "loop": True, "max_wait_secs": 20,
             "current_test": "", "iteration": 0,
             "status": "starting", "test_started_at": 0.0,
             "tests": {}, "suites": [],
@@ -338,7 +338,7 @@ def api_control():
     if suite not in known:
         return jsonify({"error": f"Unknown suite: {suite}"}), 400
 
-    size = str(d.get("size", "XS"))
+    size = str(d.get("size", "S"))
     if size not in _VALID_SIZES:
         return jsonify({"error": f"Invalid size: {size}"}), 400
 
@@ -839,7 +839,7 @@ html.light .obody .ll:hover{background:rgba(0,0,0,.04)}html.light .cmd-blk{backg
         <div class="cmd-blk"><span class="cmt"># Run all suites in a continuous loop with web dashboard</span>
 docker run --pull=always --detach --restart unless-stopped \
   <span class="flg">-p 7777:7777</span> --name traffgen jdibby/traffgen:latest \
-  --suite=all --size=XS --max-wait-secs=20 --loop
+  --suite=all --size=S --max-wait-secs=20 --loop
 
 <span class="cmt"># One-command install on fresh host (Ubuntu / Debian / Rocky / Raspberry Pi)</span>
 sudo bash &lt; &lt;(curl -s https://raw.githubusercontent.com/jdibby/traffgen/refs/heads/main/stager.sh)
@@ -1078,7 +1078,7 @@ function apply(s){
   if(!$('drawer').classList.contains('open')){
     const sel=$('cfg-suite');
     if(sel.options.length<=1&&suites.length){suites.forEach(su=>{const o=document.createElement('option');o.value=su.name;o.textContent=su.name+' — '+su.description;sel.appendChild(o);});}
-    sel.value=s.suite||'all';$('cfg-size').value=s.size||'XS';$('cfg-wait').value=s.max_wait_secs||20;$('wait-val').textContent=(s.max_wait_secs||20)+'s';$('cfg-loop').checked=!!s.loop;
+    sel.value=s.suite||'all';$('cfg-size').value=s.size||'S';$('cfg-wait').value=s.max_wait_secs||20;$('wait-val').textContent=(s.max_wait_secs||20)+'s';$('cfg-loop').checked=!!s.loop;
   }
   $('cur-cfg').innerHTML=`<span class="cfg-chip">suite:${H(s.suite||'—')}</span><span class="cfg-chip">size:${H(s.size||'—')}</span><span class="cfg-chip">wait:${s.max_wait_secs||20}s</span><span class="cfg-chip">${s.loop?'loop':'single'}</span>`;
 }
@@ -1167,7 +1167,7 @@ function openModal(name,desc){
   const td=(_lastState&&_lastState.tests&&_lastState.tests[name])||{};
   const ta=td.attempts||0,tok=td.ok||0,tf=td.fail||0;
   $('ms-att').textContent=ta?N(ta):'—';$('ms-ok').textContent=tok?N(tok):'—';$('ms-fail').textContent=tf?N(tf):'—';
-  if(_lastState){$('modal-size').value=_lastState.size||'XS';$('modal-wait').value=_lastState.max_wait_secs||20;$('modal-wv').textContent=($('modal-wait').value)+'s';$('modal-loop').checked=!!_lastState.loop;}
+  if(_lastState){$('modal-size').value=_lastState.size||'S';$('modal-wait').value=_lastState.max_wait_secs||20;$('modal-wv').textContent=($('modal-wait').value)+'s';$('modal-loop').checked=!!_lastState.loop;}
   $('modal-ov').classList.add('open');
 }
 function closeModal(){$('modal-ov').classList.remove('open');_modalSuite=null;}


### PR DESCRIPTION
## Summary

Changes the default traffic size from `XS` to `S` across the entire codebase. `XS` remains a valid option — only the default changes.

**Files updated:**
- `Dockerfile` — `CMD` default
- `stager.sh` — `docker run` command
- `generator.py` — `_WEB_STATE` fallback, `_argv_from_cmd` fallback
- `webui.py` — `_read_state()` fallback, `/api/control` fallback, About page quick-start, Settings drawer JS fallbacks
- `README.md` — all quick-start commands, CLI reference table default, architecture CMD description
- `docs/web-dashboard.md` — enabling example and layout ASCII art

https://claude.ai/code/session_01TzvcBrPJf7cnjnXSmQfkg1

---
_Generated by [Claude Code](https://claude.ai/code/session_01TzvcBrPJf7cnjnXSmQfkg1)_