### PR TITLE
fix: downgrade GOBGP_VERSION to v4.3.0 (latest existing tag)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 #   html/template, and os (CVE-2025-58183 through CVE-2026-32289 series).
 FROM golang:1.26-bookworm AS gobgp-build
 
-ARG GOBGP_VERSION=v4.5.0
+ARG GOBGP_VERSION=v4.3.0
 
 WORKDIR /tmp/gobgp
 # --depth 1 --single-branch fetches only the tagged commit, not the full history


### PR DESCRIPTION
## Summary

- `v4.5.0` does not exist on osrg/gobgp; the latest release is `v4.3.0` (released 2026-02-28)
- The `git clone --depth 1 --single-branch --branch v4.5.0` step was failing with exit code 1 because the tag didn't exist
- Downgrades `GOBGP_VERSION` to `v4.3.0`

## Test plan
- [ ] Docker build stage 1 (gobgp-build) completes successfully
- [ ] gobgp and gobgpd binaries are produced and copied to runtime image

---
_Generated by [Claude Code](https://claude.ai/code/session_01QiHkJ7DeFEB7bsfFW93bXW)_