### PR TITLE
fix: upgrade x/net to v0.48.0 to match grpc v1.79.3 requirement

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,10 +9,11 @@ ARG GOBGP_VERSION=v4.3.0
 WORKDIR /tmp/gobgp
 # --depth 1 --single-branch fetches only the tagged commit, not the full history
 # grpc@v1.79.3  fixes CVE-2026-33186 (gRPC-Go auth bypass via :path)
-# x/net@v0.45.0 fixes CVE-2025-22872, CVE-2025-47911, CVE-2025-58190 (html parser DoS/XSS)
+# x/net@v0.48.0 fixes CVE-2025-22872, CVE-2025-47911, CVE-2025-58190 (html parser DoS/XSS)
+#   (grpc v1.79.3 itself requires x/net >= v0.48.0; using v0.45.0 causes MVS conflicts)
 RUN git clone --depth 1 --single-branch --branch ${GOBGP_VERSION} \
         https://github.com/osrg/gobgp.git . && \
-    go get google.golang.org/grpc@v1.79.3 golang.org/x/net@v0.45.0 && \
+    go get google.golang.org/grpc@v1.79.3 golang.org/x/net@v0.48.0 && \
     go mod tidy && \
     go build -ldflags="-s -w" -o /tmp/gobgp-bin/gobgp  ./cmd/gobgp  && \
     go build -ldflags="-s -w" -o /tmp/gobgp-bin/gobgpd ./cmd/gobgpd && \


### PR DESCRIPTION
## Summary

- `grpc v1.79.3` requires `golang.org/x/net >= v0.48.0` in its own go.mod
- Our Dockerfile was requesting `x/net@v0.45.0` alongside `grpc@v1.79.3`, creating an MVS version conflict
- The gobgp `master` branch already ships with exactly `grpc@v1.79.3 + x/net@v0.48.0`, confirming these versions build correctly together
- Updated the `go get` pin from `v0.45.0` → `v0.48.0`; `v0.48.0` still fixes all three x/net CVEs (CVE-2025-22872, CVE-2025-47911, CVE-2025-58190)

## Test plan
- [ ] Stage 1 gobgp-build completes successfully
- [ ] All three x/net CVEs and grpc CVE-2026-33186 are resolved

---
_Generated by [Claude Code](https://claude.ai/code/session_01QiHkJ7DeFEB7bsfFW93bXW)_