### PR TITLE
feat: add authorized-use disclaimer across web UI, stager, entrypoint, and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,16 @@ Runs as a Docker container with a built-in watchdog, per-test timeout guard, and
 
 ---
 
+## ⚠ Disclaimer
+
+This tool is intended for **authorized security testing and research in controlled lab environments only**.
+
+- You are solely responsible for obtaining explicit written permission before testing any systems or networks.
+- The author(s) accept **no liability** for misuse, unauthorized access, damage, data loss, or legal consequences arising from use of this tool.
+- Use of this software constitutes acceptance of these terms.
+
+---
+
 ## ⚡ Quick Start
 
 ```bash

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,6 +1,22 @@
 #!/bin/bash
 set -e
 
+cat <<'DISCLAIMER'
+┌─────────────────────────────────────────────────────────────────────────┐
+│                          ⚠  DISCLAIMER  ⚠                              │
+│                                                                         │
+│  This tool is intended for AUTHORIZED SECURITY TESTING AND RESEARCH     │
+│  in controlled lab environments only.                                   │
+│                                                                         │
+│  • You are solely responsible for obtaining explicit written            │
+│    permission before testing any systems or networks.                   │
+│  • The author(s) accept NO liability for misuse, unauthorized access,   │
+│    damage, data loss, or legal consequences arising from use of this    │
+│    tool.                                                                │
+│  • Use of this software constitutes acceptance of these terms.          │
+└─────────────────────────────────────────────────────────────────────────┘
+DISCLAIMER
+
 # Install custom CA certificates before launching the generator so every tool
 # in the container (Ruby/Metasploit, openssl s_client, curl, Go) trusts them.
 #

--- a/stager.sh
+++ b/stager.sh
@@ -15,6 +15,22 @@
 
 set -euo pipefail
 
+cat <<'DISCLAIMER'
+┌─────────────────────────────────────────────────────────────────────────┐
+│                          ⚠  DISCLAIMER  ⚠                              │
+│                                                                         │
+│  This tool is intended for AUTHORIZED SECURITY TESTING AND RESEARCH     │
+│  in controlled lab environments only.                                   │
+│                                                                         │
+│  • You are solely responsible for obtaining explicit written            │
+│    permission before testing any systems or networks.                   │
+│  • The author(s) accept NO liability for misuse, unauthorized access,   │
+│    damage, data loss, or legal consequences arising from use of this    │
+│    tool.                                                                │
+│  • Use of this software constitutes acceptance of these terms.          │
+└─────────────────────────────────────────────────────────────────────────┘
+DISCLAIMER
+
 # ── Privilege check ───────────────────────────────────────────────────────────
 if [ "$(id -u)" -ne 0 ]; then
     echo "ERROR: Run as root or via sudo." >&2

--- a/webui.py
+++ b/webui.py
@@ -1394,6 +1394,37 @@ wireTip('h-net-spark',10,6,()=>_hNetHist,p=>[
 ]);
 checkRole();
 connect();
+
+// ── Disclaimer modal (shown once per browser session) ─────────────────────
+(function(){
+  if(sessionStorage.getItem('disclaimer_ack'))return;
+  const overlay=document.createElement('div');
+  overlay.style.cssText='position:fixed;inset:0;z-index:9999;background:rgba(0,0,0,.85);display:flex;align-items:center;justify-content:center;padding:20px';
+  overlay.innerHTML=`
+<div style="background:var(--surf);border:1px solid var(--amber);border-radius:8px;max-width:540px;width:100%;padding:28px 32px;box-shadow:0 8px 40px rgba(0,0,0,.6)">
+  <div style="display:flex;align-items:center;gap:10px;margin-bottom:16px">
+    <span style="font-size:22px">⚠</span>
+    <span style="font-size:16px;font-weight:700;color:var(--amber)">Disclaimer</span>
+  </div>
+  <p style="color:var(--text);line-height:1.65;margin-bottom:12px">
+    This tool is intended for <strong>authorized security testing and research
+    in controlled lab environments only</strong>.
+  </p>
+  <ul style="color:var(--text);line-height:1.65;padding-left:18px;margin-bottom:20px">
+    <li style="margin-bottom:6px">You are solely responsible for obtaining explicit written permission before testing any systems or networks.</li>
+    <li style="margin-bottom:6px">The author(s) accept <strong>no liability</strong> for misuse, unauthorized access, damage, data loss, or legal consequences arising from use of this tool.</li>
+    <li>Use of this software constitutes acceptance of these terms.</li>
+  </ul>
+  <button id="disclaimer-ack" style="width:100%;padding:10px;background:var(--amber);color:#000;font-weight:700;font-size:13px;border:none;border-radius:6px;cursor:pointer">
+    I Understand — Continue
+  </button>
+</div>`;
+  document.body.appendChild(overlay);
+  document.getElementById('disclaimer-ack').addEventListener('click',function(){
+    sessionStorage.setItem('disclaimer_ack','1');
+    overlay.remove();
+  });
+})();
 </script>
 </body></html>"""
 _LOG_HTML = """<!DOCTYPE html>


### PR DESCRIPTION
## Summary

Adds an authorized-use-only disclaimer in all four entry points:

- **`webui.py`** — Full-screen amber-bordered modal on every new browser session (`sessionStorage`-gated so it doesn't re-appear on refresh). Requires clicking "I Understand — Continue" to dismiss.
- **`docker-entrypoint.sh`** — Box-drawn banner printed to stdout at container startup (before any CA/TLS logic runs).
- **`stager.sh`** — Same banner printed before the installer does anything (before OS detection and privilege check).
- **`README.md`** — Dedicated `⚠ Disclaimer` section added directly after the intro paragraph, before Quick Start.

## Test plan
- [ ] Run container — disclaimer banner appears in logs before any other output
- [ ] Run stager.sh — disclaimer banner appears as the first output
- [ ] Open web UI — disclaimer modal appears; dismisses cleanly on button click; does not re-appear on refresh within the same browser session
- [ ] README disclaimer section renders correctly on GitHub

---
_Generated by [Claude Code](https://claude.ai/code/session_01QiHkJ7DeFEB7bsfFW93bXW)_