### PR TITLE
fix: reduce bigfile read timeout to 3s for fast provider failover

### DIFF
--- a/generator.py
+++ b/generator.py
@@ -930,7 +930,7 @@ def bigfile() -> None:
         ui_info(f"Trying {url}")
         try:
             with requests.get(
-                url, stream=True, verify=False, timeout=(3, 60),
+                url, stream=True, verify=False, timeout=(3, 3),
                 headers={"User-Agent": ua},
             ) as resp:
                 if resp.status_code in (403, 429, 451):


### PR DESCRIPTION
## Summary

- `timeout=(3, 60)` → `timeout=(3, 3)` in the `bigfile()` function
- The tuple is `(connect_timeout, read_timeout)` — the read half governs how long requests waits for any data to arrive on the socket between chunk reads
- With 60s, a blocked/slow provider stalls the loop for up to a minute before failing over
- With 3s, a provider that stops delivering data is abandoned within ~3 seconds
- Active downloads are unaffected: a live server delivering a large file sends chunks continuously, well within the 3s window

## Test plan
- [ ] Blocked/unavailable provider fails and moves to the next URL within 2–3 seconds
- [ ] A healthy provider completes a full download without interruption

---
_Generated by [Claude Code](https://claude.ai/code/session_01QiHkJ7DeFEB7bsfFW93bXW)_