### PR TITLE
perf: pre-built msf-base image + registry cache to cut CI build time

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -35,5 +35,5 @@ jobs:
           tags: |
             jdibby/traffgen:latest
             jdibby/traffgen:${{ github.sha }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=registry,ref=docker.io/jdibby/traffgen:buildcache
+          cache-to: type=registry,ref=docker.io/jdibby/traffgen:buildcache,mode=max

--- a/.github/workflows/msf-base-publish.yml
+++ b/.github/workflows/msf-base-publish.yml
@@ -1,0 +1,49 @@
+name: Build and Push msf-base
+
+# Rebuild the pre-built Metasploit base image.  Run this manually whenever
+# the Metasploit version or gem set changes, or when triggered automatically
+# by a change to Dockerfile.msf-base.
+#
+# The main docker-publish.yml pulls jdibby/msf-base:latest rather than
+# running bundle install from scratch, cutting 15-25 min off every build.
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - 'Dockerfile.msf-base'
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU (for multi-arch emulation)
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push msf-base
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile.msf-base
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          push: true
+          tags: |
+            jdibby/msf-base:latest
+            jdibby/msf-base:${{ github.sha }}
+          cache-from: type=registry,ref=docker.io/jdibby/msf-base:buildcache
+          cache-to: type=registry,ref=docker.io/jdibby/msf-base:buildcache,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,71 +19,12 @@ RUN git clone --depth 1 --single-branch --branch ${GOBGP_VERSION} \
     go build -ldflags="-s -w" -o /tmp/gobgp-bin/gobgpd ./cmd/gobgpd && \
     strip /tmp/gobgp-bin/gobgp /tmp/gobgp-bin/gobgpd
 
-# ---------- Stage 2: build Metasploit (fat builder) ----------
-FROM debian:bookworm-slim AS msf-build
-ENV DEBIAN_FRONTEND=noninteractive
-
-# Build-time toolchain only — nothing from this layer ships to runtime
-RUN apt-get update && apt-get upgrade -y --no-install-recommends && \
-    apt-get install -y --no-install-recommends \
-    ca-certificates git ruby-full build-essential pkg-config \
-    libssl-dev libffi-dev libpcap-dev libreadline-dev zlib1g-dev \
-    libxml2-dev libxslt1-dev libyaml-dev libpq-dev sqlite3 libsqlite3-dev \
-  && rm -rf /var/lib/apt/lists/*
-
-WORKDIR /opt
-# --depth 1 skips the full MSF git history (~1 GB uncompressed)
-RUN git clone --depth 1 \
-        https://github.com/rapid7/metasploit-framework.git metasploit-framework
-WORKDIR /opt/metasploit-framework
-
-# Install bundler + vendor gems (no dev/test), small fixes, then aggressive cleanup
-RUN gem install --no-document bundler && \
-    bundle config set --local without 'development test' && \
-    bundle config set --local path '/opt/metasploit-framework/vendor/bundle' && \
-    (grep -Eq "^\s*gem ['\"]stringio['\"]" Gemfile && \
-       sed -E -i "s|^\s*gem ['\"]stringio['\"].*|gem 'stringio', '3.1.1'|" Gemfile || \
-       echo "gem 'stringio', '3.1.1'" >> Gemfile) && \
-    (grep -Eq "^\s*gem ['\"]parallel['\"]" Gemfile || echo "gem 'parallel'" >> Gemfile) && \
-    NOKOGIRI_USE_SYSTEM_LIBRARIES=1 bundle install --jobs 4 --retry 3 && \
-    bundle update --conservative rack rexml webrick json addressable net-imap zlib && \
-    bundle clean --force && \
-    rm -rf ~/.gem ~/.bundle /root/.bundle vendor/bundle/ruby/*/cache tmp/cache && \
-    # Remove default stringio gemspec to avoid duplicate warnings
-    find / -name "stringio-3.0.4.gemspec" -delete 2>/dev/null || true
-
-# Aggressive post-install size reduction — everything below is safe for check-only use
-RUN \
-    # Drop .git — history not needed at runtime (~hundreds of MB)
-    rm -rf /opt/metasploit-framework/.git && \
-    # Remove MSF module directories not needed for check-only operation
-    rm -rf /opt/metasploit-framework/modules/payloads \
-           /opt/metasploit-framework/modules/post \
-           /opt/metasploit-framework/modules/encoders \
-           /opt/metasploit-framework/modules/nops \
-           /opt/metasploit-framework/modules/evasion && \
-    # Remove documentation, developer tools, and exploit data blobs
-    rm -rf /opt/metasploit-framework/documentation \
-           /opt/metasploit-framework/tools \
-           /opt/metasploit-framework/data/exploits \
-           /opt/metasploit-framework/data/meterpreter \
-           /opt/metasploit-framework/data/templates && \
-    # Strip debug symbols from native extension .so files in the vendor bundle
-    find /opt/metasploit-framework/vendor/bundle -name "*.so" \
-         -exec strip --strip-debug {} \; 2>/dev/null || true && \
-    # Remove gem spec/test directories (not needed at runtime)
-    find /opt/metasploit-framework/vendor/bundle -type d \
-         \( -name spec -o -name test -o -name tests -o -name "test-unit" \) \
-         -exec rm -rf {} + 2>/dev/null || true && \
-    # Remove C/C++ source and build artefacts used only during gem compilation
-    find /opt/metasploit-framework/vendor/bundle -name "*.c"       -delete 2>/dev/null; \
-    find /opt/metasploit-framework/vendor/bundle -name "*.h"       -delete 2>/dev/null; \
-    find /opt/metasploit-framework/vendor/bundle -name "Makefile"  -delete 2>/dev/null || true && \
-    # Remove cached .gem archives (already installed, wasting space)
-    find /opt/metasploit-framework/vendor/bundle -name "*.gem"     -delete 2>/dev/null || true && \
-    # Remove Ruby ri documentation from vendor bundle
-    find /opt/metasploit-framework/vendor/bundle -type d -name "ri" \
-         -exec rm -rf {} + 2>/dev/null || true
+# ---------- Stage 2: pre-built Metasploit base ----------
+# Rebuilt separately via .github/workflows/msf-base-publish.yml whenever
+# the Metasploit version or gem set changes.  Pulling this image is fast;
+# the 15-25 min bundle-install cost only runs during an msf-base rebuild.
+# COPY --from=msf-build below pulls only /opt/metasploit-framework.
+FROM jdibby/msf-base:latest AS msf-build
 
 # ---------- Stage 3: runtime ----------
 FROM debian:bookworm-slim

--- a/Dockerfile.msf-base
+++ b/Dockerfile.msf-base
@@ -1,0 +1,74 @@
+# Standalone build of the Metasploit vendor bundle used as a pre-built base
+# for the main traffgen image.
+#
+# Rebuild this image only when the Metasploit version or the gem dependency
+# set changes.  Trigger via the Actions tab (workflow_dispatch) or by pushing
+# a change to this file.  The main traffgen build just pulls the result —
+# no git clone, no bundle install.
+#
+# Workflow: .github/workflows/msf-base-publish.yml
+# Image:    jdibby/msf-base:latest
+FROM debian:bookworm-slim
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Build-time toolchain — compiles native gem extensions; none of this ships
+# to the runtime image (only /opt/metasploit-framework is COPY'd across).
+RUN apt-get update && apt-get upgrade -y --no-install-recommends && \
+    apt-get install -y --no-install-recommends \
+    ca-certificates git ruby-full build-essential pkg-config \
+    libssl-dev libffi-dev libpcap-dev libreadline-dev zlib1g-dev \
+    libxml2-dev libxslt1-dev libyaml-dev libpq-dev sqlite3 libsqlite3-dev \
+  && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /opt
+# --depth 1 skips the full MSF git history (~1 GB uncompressed)
+RUN git clone --depth 1 \
+        https://github.com/rapid7/metasploit-framework.git metasploit-framework
+WORKDIR /opt/metasploit-framework
+
+# Install bundler + vendor gems (no dev/test), small fixes, then aggressive cleanup
+RUN gem install --no-document bundler && \
+    bundle config set --local without 'development test' && \
+    bundle config set --local path '/opt/metasploit-framework/vendor/bundle' && \
+    (grep -Eq "^\s*gem ['\"]stringio['\"]" Gemfile && \
+       sed -E -i "s|^\s*gem ['\"]stringio['\"].*|gem 'stringio', '3.1.1'|" Gemfile || \
+       echo "gem 'stringio', '3.1.1'" >> Gemfile) && \
+    (grep -Eq "^\s*gem ['\"]parallel['\"]" Gemfile || echo "gem 'parallel'" >> Gemfile) && \
+    NOKOGIRI_USE_SYSTEM_LIBRARIES=1 bundle install --jobs 4 --retry 3 && \
+    bundle update --conservative rack rexml webrick json addressable net-imap zlib && \
+    bundle clean --force && \
+    rm -rf ~/.gem ~/.bundle /root/.bundle vendor/bundle/ruby/*/cache tmp/cache && \
+    find / -name "stringio-3.0.4.gemspec" -delete 2>/dev/null || true
+
+# Aggressive post-install size reduction — everything below is safe for check-only use
+RUN \
+    # Drop .git — history not needed at runtime (~hundreds of MB)
+    rm -rf /opt/metasploit-framework/.git && \
+    # Remove MSF module directories not needed for check-only operation
+    rm -rf /opt/metasploit-framework/modules/payloads \
+           /opt/metasploit-framework/modules/post \
+           /opt/metasploit-framework/modules/encoders \
+           /opt/metasploit-framework/modules/nops \
+           /opt/metasploit-framework/modules/evasion && \
+    # Remove documentation, developer tools, and exploit data blobs
+    rm -rf /opt/metasploit-framework/documentation \
+           /opt/metasploit-framework/tools \
+           /opt/metasploit-framework/data/exploits \
+           /opt/metasploit-framework/data/meterpreter \
+           /opt/metasploit-framework/data/templates && \
+    # Strip debug symbols from native extension .so files in the vendor bundle
+    find /opt/metasploit-framework/vendor/bundle -name "*.so" \
+         -exec strip --strip-debug {} \; 2>/dev/null || true && \
+    # Remove gem spec/test directories (not needed at runtime)
+    find /opt/metasploit-framework/vendor/bundle -type d \
+         \( -name spec -o -name test -o -name tests -o -name "test-unit" \) \
+         -exec rm -rf {} + 2>/dev/null || true && \
+    # Remove C/C++ source and build artefacts used only during gem compilation
+    find /opt/metasploit-framework/vendor/bundle -name "*.c"       -delete 2>/dev/null; \
+    find /opt/metasploit-framework/vendor/bundle -name "*.h"       -delete 2>/dev/null; \
+    find /opt/metasploit-framework/vendor/bundle -name "Makefile"  -delete 2>/dev/null || true && \
+    # Remove cached .gem archives (already installed, wasting space)
+    find /opt/metasploit-framework/vendor/bundle -name "*.gem"     -delete 2>/dev/null || true && \
+    # Remove Ruby ri documentation from vendor bundle
+    find /opt/metasploit-framework/vendor/bundle -type d -name "ri" \
+         -exec rm -rf {} + 2>/dev/null || true


### PR DESCRIPTION
## Summary

Eliminates the 15–25 min Metasploit `bundle install` from every CI run.

### What changed

**`Dockerfile.msf-base`** (new)
Standalone Dockerfile containing exactly what was Stage 2. Produces `jdibby/msf-base:latest` — a multi-arch image with `/opt/metasploit-framework` fully built and cleaned up.

**`.github/workflows/msf-base-publish.yml`** (new)
Builds and pushes `jdibby/msf-base:latest` for `amd64/arm64/arm/v7`. Triggers on:
- Manual dispatch from the Actions tab (routine use)
- Any push to `Dockerfile.msf-base` on main (automatic when Metasploit version/gems change)

Uses `jdibby/msf-base:buildcache` as its own registry cache so repeat msf-base builds are also fast.

**`Dockerfile`**
Stage 2 replaced with a single line:
```dockerfile
FROM jdibby/msf-base:latest AS msf-build
```
The `COPY --from=msf-build` in Stage 3 is unchanged — it still pulls only `/opt/metasploit-framework`.

**`.github/workflows/docker-publish.yml`**
Switched from `type=gha` (evicted after 10 GB, doesn't survive well across runs) to `type=registry` pointing at `jdibby/traffgen:buildcache`. BuildKit stores all intermediate layer blobs in that tag; on the next run it pulls and reuses anything unchanged.

### First-time setup

Run the **Build and Push msf-base** workflow manually from the Actions tab once to prime `jdibby/msf-base:latest` before the next traffgen build.

### Expected build time after this change

| | Before | After |
|---|---|---|
| Main build (warm) | 25–40 min | ~3–5 min |
| Main build (cold) | 25–40 min | ~5–8 min (pull msf-base + gobgp compile) |
| msf-base rebuild | n/a | 20–30 min (only when needed) |

---
_Generated by [Claude Code](https://claude.ai/code/session_01QiHkJ7DeFEB7bsfFW93bXW)_