### PR TITLE
fix: bootstrap msf-base automatically when image is missing from registry

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -26,6 +26,30 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      # Check whether jdibby/msf-base:latest already exists on Docker Hub.
+      # On the very first run (or after a registry wipe) it won't — the next
+      # step builds it.  All subsequent runs skip that step in under a second.
+      - name: Check if msf-base image exists
+        id: msf-check
+        run: |
+          if docker manifest inspect jdibby/msf-base:latest > /dev/null 2>&1; then
+            echo "exists=true"  >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Build and push msf-base (first-time bootstrap)
+        if: steps.msf-check.outputs.exists == 'false'
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile.msf-base
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          push: true
+          tags: jdibby/msf-base:latest
+          cache-from: type=registry,ref=docker.io/jdibby/msf-base:buildcache
+          cache-to: type=registry,ref=docker.io/jdibby/msf-base:buildcache,mode=max
+
       - name: Build and push
         uses: docker/build-push-action@v6
         with:


### PR DESCRIPTION
## Summary

Fixes the `msf-base:latest: not found` error that occurs on the first run before the image has ever been built.

Adds two steps before the main build in `docker-publish.yml`:

1. **Check** — `docker manifest inspect jdibby/msf-base:latest` to see if the image exists. Takes under a second on normal runs.
2. **Bootstrap** — only runs when the check fails. Builds and pushes `msf-base` for all three platforms inline, then continues to the traffgen build.

Normal workflow after this first run is unchanged — the check step skips instantly and the bootstrap step is never reached again unless the registry is wiped.

## Test plan
- [ ] First run: bootstrap step triggers, msf-base is built and pushed, traffgen build succeeds
- [ ] Second run: check step outputs `exists=true`, bootstrap step is skipped, traffgen build completes in ~3–5 min

---
_Generated by [Claude Code](https://claude.ai/code/session_01QiHkJ7DeFEB7bsfFW93bXW)_