### PR TITLE
feat: add s3 suite (closes #2) + fix disclaimer banner alignment

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Docker Hub](https://img.shields.io/docker/pulls/jdibby/traffgen?logo=docker&label=Docker%20Hub)](https://hub.docker.com/r/jdibby/traffgen)
 [![Multi-arch](https://img.shields.io/badge/arch-amd64%20%7C%20arm64%20%7C%20arm%2Fv7-blue?logo=linux)](https://hub.docker.com/r/jdibby/traffgen)
 
-Traffgen simulates realistic network traffic across **47 test suites** — DNS, HTTP/S, FTP, SSH, BGP, ICMP, NTP, SNMP, DoH, DoT, C2 beacons, DNS exfiltration, AI/LLM DLP, Metasploit checks, malware downloads, phishing probes, web scanning, and more.
+Traffgen simulates realistic network traffic across **48 test suites** — DNS, HTTP/S, FTP, SSH, BGP, ICMP, NTP, SNMP, DoH, DoT, C2 beacons, DNS exfiltration, AI/LLM DLP, Metasploit checks, malware downloads, phishing probes, web scanning, and more.
 
 Purpose-built to stress-test **firewalls**, **IDS/IPS**, **URL filters**, **DLP engines**, **CASB platforms**, and **SIEM pipelines**.
 
@@ -116,6 +116,7 @@ The dashboard includes:
 | 🔒 `https` | HTTPS HEAD requests to a wide endpoint pool followed by an iterative TLS crawl. Tests TLS inspection policy, certificate validation enforcement, and HTTPS download logging. |
 | 🕷️ `crawl` | Iterative web crawl from a configurable seed URL (`--crawl-start`). Follows links up to a depth that scales with `--size`. Mimics a browser session for URL categorisation and user-activity analytics testing. |
 | ⏱️ `url-response` | Measures HTTPS response times across a diverse URL set using the Python `requests` library. Populates URL-filter logs and response-time dashboards. |
+| 🪣 `s3` | Simulates S3 bucket upload and download traffic. GET requests target a mix of public AWS datasets and private-style bucket paths (200 or 403 — both generate CASB-visible S3 traffic). PUT requests upload small synthetic payloads containing PII, credentials, and confidential strings to S3 paths — requests return 403 (no credentials) but are fully visible to DLP and CASB engines as cloud-upload/exfiltration attempts. Also targets Wasabi and Backblaze B2 S3-compatible endpoints. |
 | 💾 `bigfile` | Streams an HTTP download to `/dev/null` — file size scales with `--size` (XS=10 MB, S=100 MB, M=1 GB, L=2 GB, XL=5 GB). Tests large-file and bandwidth-cap policies across the full volume range without always hitting the ceiling. |
 | 📂 `ftp` | FTP file download via `curl` with rate limiting against a public test server. Validates FTP inspection, logging, and file-transfer policy enforcement. |
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -3,7 +3,7 @@ set -e
 
 cat <<'DISCLAIMER'
 ┌─────────────────────────────────────────────────────────────────────────┐
-│                          ⚠  DISCLAIMER  ⚠                              │
+│                             ! DISCLAIMER !                              │
 │                                                                         │
 │  This tool is intended for AUTHORIZED SECURITY TESTING AND RESEARCH     │
 │  in controlled lab environments only.                                   │

--- a/endpoints.py
+++ b/endpoints.py
@@ -56,6 +56,10 @@ Variable index (matches generator.py usage names 1-to-1):
   LLM / AI APIs
     llm_api_endpoints   REST API paths for major AI providers (llm_dlp)
     llm_web_endpoints   Browser-facing AI app URLs (llm_dlp, ai_https)
+
+  S3 / cloud object storage
+    s3_download_urls    S3 bucket/object URLs for GET simulation (s3_sim)
+    s3_upload_targets   S3 bucket/key paths for PUT upload simulation (s3_sim)
 """
 
 # ── DNS resolvers ──────────────────────────────────────────────────────────────
@@ -2891,4 +2895,55 @@ llm_web_endpoints = [
     "https://einstein.salesforce.com",
     "https://aws.amazon.com/bedrock",
     "https://azure.microsoft.com/en-us/products/ai-services/openai-service",
+]
+
+# ── S3 / Cloud Object Storage ─────────────────────────────────────────────────
+#
+# s3_download_urls: GET targets — mix of public AWS datasets and private-bucket
+#   URLs.  Public ones return 200/XML; private ones return 403 AccessDenied.
+#   Both generate CASB-visible S3 GET traffic.
+#
+# s3_upload_targets: PUT targets — realistic bucket/key paths.  All return 403
+#   (no credentials) but the upload attempt + payload is visible to DLP/CASB.
+#   Payloads are chosen in generator.py from a set of synthetic PII / secret
+#   strings designed to trigger DLP content-inspection rules.
+
+s3_download_urls: list[str] = [
+    # Public AWS datasets — may return 200 with XML listing or object data
+    "https://commoncrawl.s3.amazonaws.com/crawl-data/CC-MAIN-2023-50/warc.paths.gz",
+    "https://noaa-goes16.s3.amazonaws.com/",
+    "https://sentinel-s2-l1c.s3.amazonaws.com/",
+    "https://s3.amazonaws.com/tripdata/",
+    "https://landsat-pds.s3.amazonaws.com/",
+    "https://aws-earth-mo-atmospheric-mogreps-uk-prd.s3.amazonaws.com/",
+    # Private / corporate-style buckets — 403 expected, S3 traffic generated
+    "https://s3.amazonaws.com/corporate-data-exports/report-2024-q4.csv",
+    "https://company-backups.s3.amazonaws.com/full-backup-latest.tar.gz",
+    "https://prod-db-snapshots.s3.us-west-2.amazonaws.com/snapshot-20241201.sql.gz",
+    "https://s3.us-east-1.amazonaws.com/hr-records/employees.xlsx",
+    "https://internal-docs.s3.amazonaws.com/architecture-overview.pdf",
+    "https://app-logs.s3.us-east-2.amazonaws.com/logs/2024/11/app.log.gz",
+    "https://my-website-assets.s3.amazonaws.com/images/banner.jpg",
+    "https://s3.eu-west-1.amazonaws.com/gdpr-exports/data-subject-export.zip",
+    # S3-compatible storage providers
+    "https://s3.wasabisys.com/",
+    "https://s3.us-west-002.backblazeb2.com/",
+]
+
+s3_upload_targets: list[str] = [
+    # AWS S3 — realistic bucket/key paths for PUT simulation
+    # All return 403 (no credentials) but the upload traffic is CASB/DLP visible
+    "https://s3.amazonaws.com/data-exfil-test/financial-records.csv",
+    "https://s3.amazonaws.com/backup-bucket-prod/sensitive-data.zip",
+    "https://s3.us-east-1.amazonaws.com/corp-uploads/employee-list.xlsx",
+    "https://uploads.s3.us-west-2.amazonaws.com/user-data/pii-export.json",
+    "https://company-archive.s3.amazonaws.com/2024/confidential.tar.gz",
+    "https://s3.amazonaws.com/cloud-sync/credentials.env",
+    "https://s3.eu-west-1.amazonaws.com/gdpr-data/personal-records.csv",
+    "https://s3.amazonaws.com/dev-artifacts/source-code.zip",
+    "https://data-lake.s3.us-east-2.amazonaws.com/raw/customer-dump.parquet",
+    "https://s3.ap-southeast-1.amazonaws.com/offshore-backup/db-export.sql.gz",
+    # S3-compatible storage providers
+    "https://s3.wasabisys.com/exfil-test-bucket/payload.bin",
+    "https://s3.us-west-002.backblazeb2.com/traffgen-test/upload.dat",
 ]

--- a/generator.py
+++ b/generator.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 """
-generator.py — Traffic Generator v2.4.0
+generator.py — Traffic Generator v2.5.0
 ========================================
 Simulates realistic network traffic across a wide range of protocols and
 behaviours: DNS, HTTP/HTTPS/HTTP3, FTP, SSH, NTP, BGP, ICMP, SNMP,
@@ -257,6 +257,7 @@ _SUITE_DESCRIPTIONS: list[tuple[str, str]] = [
     ("pornography",      "HTTPS crawl of adult-content endpoints"),
     ("snmp",             "SNMPv2c walks with rotating community strings"),
     ("squatting",        "dnstwist typosquatting generation for popular domains"),
+    ("s3",               "S3 upload/download simulation: GET public objects + PUT synthetic DLP payloads"),
     ("ssh",              "Non-interactive SSH connection attempts"),
     ("url-response",     "Measure HTTPS response times via requests library"),
     ("virus",            "Download known-virus samples (to /dev/null)"),
@@ -1589,6 +1590,75 @@ def dlp_sim_https() -> None:
         ui_error(f"[dlp_sim_https] {e}")
 
 
+def s3_sim() -> None:
+    """
+    Simulate S3 bucket upload and download traffic for CASB, DLP, and
+    cloud-access policy validation.
+
+    Download phase: GET requests to public and private S3 URLs.  Accepts
+    2xx, 403, and 404 as valid responses — all generate CASB-visible S3
+    traffic regardless of whether the bucket is publicly accessible.
+
+    Upload phase: PUT requests with small synthetic payloads (PII, creds,
+    confidential text) to S3 bucket paths.  Requests return 403 (no
+    credentials) but are visible to DLP/CASB engines as upload/exfil
+    attempts.
+    """
+    n_dl = _size_to_limits(ARGS.size, 2, 4, 6, len(s3_download_urls))
+    n_ul = _size_to_limits(ARGS.size, 1, 2, 3, len(s3_upload_targets))
+    ua   = random.choice(user_agents)
+    ui_banner("S3 Simulation", f"{n_dl} downloads + {n_ul} uploads")
+
+    _DLP_PAYLOADS = [
+        b"name,ssn,dob\nJohn Doe,123-45-6789,1985-03-12\nJane Smith,987-65-4321,1990-07-22\n",
+        b'{"employees":[{"id":1001,"name":"Alice","salary":95000,"ssn":"555-12-3456"}]}\n',
+        b"CONFIDENTIAL — Q4 Revenue: $4,320,000 — Do not distribute\n",
+        b"aws_access_key_id=AKIAIOSFODNN7EXAMPLE\naws_secret_access_key=wJalrXUtnFEMI/K7MDENG\n",
+        b"password=Tr0ub4dor&3\ndb_host=prod-db.internal\ndatabase=customers\n",
+    ]
+
+    # ── Download phase ────────────────────────────────────────────────────
+    urls_dl = random.sample(s3_download_urls, min(n_dl, len(s3_download_urls)))
+    for i, url in enumerate(urls_dl, 1):
+        try:
+            with requests.get(
+                url, stream=True, verify=False, timeout=(3, 3),
+                headers={"User-Agent": ua},
+                allow_redirects=True,
+            ) as resp:
+                resp.raw.read(65536)  # consume a small chunk then close
+            console.log(
+                f"s3-get ({i}/{n_dl}) {url}  [{_status_style(resp.status_code)}]HTTP {resp.status_code}[/]"
+            )
+            _stats.record(resp.status_code)
+        except Exception as e:
+            console.log(f"[yellow]s3-get ({i}/{n_dl}) {url}  {e.__class__.__name__}[/]")
+            _stats.fail()
+
+    # ── Upload phase ──────────────────────────────────────────────────────
+    targets_ul = random.sample(s3_upload_targets, min(n_ul, len(s3_upload_targets)))
+    payload = random.choice(_DLP_PAYLOADS)
+    for i, url in enumerate(targets_ul, 1):
+        try:
+            resp = requests.put(
+                url, data=payload, verify=False, timeout=(3, 5),
+                headers={
+                    "User-Agent":     ua,
+                    "Content-Type":   "application/octet-stream",
+                    "Content-Length": str(len(payload)),
+                },
+            )
+            console.log(
+                f"s3-put ({i}/{n_ul}) {url}  [{_status_style(resp.status_code)}]HTTP {resp.status_code}[/]"
+            )
+            _stats.record(resp.status_code)
+        except Exception as e:
+            console.log(f"[yellow]s3-put ({i}/{n_ul}) {url}  {e.__class__.__name__}[/]")
+            _stats.fail()
+
+    ui_ok("S3 simulation complete")
+
+
 def malware_download() -> None:
     """
     Download known-malware files (PE samples, archives) to /dev/null.
@@ -2547,6 +2617,7 @@ _SUITE_MAP: dict[str, list] = {
     "phishing-domains": [github_phishing_domain_check],
     "pornography":      [pornography_crawl],
     "snmp":             [snmp_random],
+    "s3":               [s3_sim],
     "squatting":        [squatting_domains],
     "ssh":              [ssh_random],
     "url-response":     [urlresponse_random],

--- a/stager.sh
+++ b/stager.sh
@@ -17,7 +17,7 @@ set -euo pipefail
 
 cat <<'DISCLAIMER'
 ┌─────────────────────────────────────────────────────────────────────────┐
-│                          ⚠  DISCLAIMER  ⚠                              │
+│                             ! DISCLAIMER !                              │
 │                                                                         │
 │  This tool is intended for AUTHORIZED SECURITY TESTING AND RESEARCH     │
 │  in controlled lab environments only.                                   │


### PR DESCRIPTION
## Summary

### S3 suite — closes #2

Implements `--suite=s3` with two phases per run:

**Download phase** — GET requests to a mix of:
- Public AWS datasets (`commoncrawl`, `noaa-goes16`, `sentinel-s2`, `tripdata`, `landsat-pds`) — may return 200 with data or XML listing
- Private-style bucket paths (`corporate-data-exports`, `hr-records`, `prod-db-snapshots`, etc.) — return 403, but the GET traffic is fully CASB-visible
- Wasabi and Backblaze B2 S3-compatible endpoints

**Upload phase** — PUT requests with synthetic DLP-detectable payloads (CSV with SSN/DOB, JSON with salary data, plaintext credentials, AWS key pairs) to realistic S3 bucket/key paths. All return 403 (no credentials) but are visible to DLP and CASB engines as upload/exfiltration attempts.

- `endpoints.py`: `s3_download_urls` (16) and `s3_upload_targets` (12)
- `generator.py`: `s3_sim()`, registered in `_SUITE_DESCRIPTIONS` and `_SUITE_MAP`; version bumped to 2.5.0
- `README.md`: suite count 47 → 48, `s3` row added to suite table

### Disclaimer banner fix

- `⚠` (U+26A0) is "ambiguous width" in Unicode — some terminals render it as 2 columns causing the right border to shift right
- Also: the header line was 72 chars wide but the box is 73 chars wide (1 char short)
- Fix: replace `⚠  DISCLAIMER  ⚠` with `! DISCLAIMER !` (ASCII, always single-width) properly centered at 29+14+30=73 in both `stager.sh` and `docker-entrypoint.sh`

## Test plan
- [ ] `--suite=s3` runs without error; GET and PUT attempts logged with HTTP status codes
- [ ] Disclaimer banner renders with aligned right border on Linux terminal

---
_Generated by [Claude Code](https://claude.ai/code/session_01QiHkJ7DeFEB7bsfFW93bXW)_