### PR TITLE
fix: scale domain-check probe count with --size; raise timeout to 3s

### DIFF
--- a/generator.py
+++ b/generator.py
@@ -2620,7 +2620,7 @@ def _probe_domain_list(local_path: str, n: int = 10) -> None:
         for i, domain in enumerate(sample, 1):
             url = f"https://{domain}"
             try:
-                r = requests.get(url, timeout=1, verify=False, allow_redirects=True)
+                r = requests.get(url, timeout=3, verify=False, allow_redirects=True)
                 console.log(f"({i}/{len(sample)}) {url}  →  {r.status_code}")
                 _stats.record(str(r.status_code))
             except requests.exceptions.ConnectionError as e:
@@ -2645,7 +2645,8 @@ def github_domain_check() -> None:
     Download (or reuse a cached copy of) the Hagezi multi-category DNS
     blocklist from GitHub, then probe a random sample of domains from it.
     """
-    ui_banner("GitHub Domain Check", "Hagezi blocklist sample")
+    n = _size_to_limits(ARGS.size, 20, 50, 100, 200)
+    ui_banner("GitHub Domain Check", f"Hagezi blocklist — {n} domains")
     local = "git-domains-list"
     url   = "https://raw.githubusercontent.com/hagezi/dns-blocklists/main/domains/multi.txt"
     try:
@@ -2655,7 +2656,7 @@ def github_domain_check() -> None:
                 return
         else:
             console.log(f"Using cached: {local}")
-        _probe_domain_list(local, n=10)
+        _probe_domain_list(local, n=n)
         ui_ok("GitHub domain check complete")
     except Exception as e:
         ui_error(f"[github_domain_check] {e}")
@@ -2666,7 +2667,8 @@ def github_phishing_domain_check() -> None:
     Download (or reuse a cached copy of) the Phishing.Database active
     phishing domain list from GitHub, then probe a random sample.
     """
-    ui_banner("Phishing Domain Check", "Phishing.Database active list")
+    n = _size_to_limits(ARGS.size, 20, 50, 100, 200)
+    ui_banner("Phishing Domain Check", f"Phishing.Database active list — {n} domains")
     local = "git-phishing-list"
     url   = (
         "https://raw.githubusercontent.com/Phishing-Database/Phishing.Database"
@@ -2679,7 +2681,7 @@ def github_phishing_domain_check() -> None:
                 return
         else:
             console.log(f"Using cached: {local}")
-        _probe_domain_list(local, n=10)
+        _probe_domain_list(local, n=n)
         ui_ok("Phishing domain check complete")
     except Exception as e:
         ui_error(f"[github_phishing_domain_check] {e}")


### PR DESCRIPTION
## Summary

`github_domain_check` and `github_phishing_domain_check` were hardcoded at `n=10` probes regardless of `--size`, which is why the Security tab barely showed any data for these suites.

**Changes:**
- Probe count now scales with `--size`: XS=20, S=50, M=100, XL=200
- `_probe_domain_list` request timeout raised from 1s → 3s so proxy block pages (HTTP 403) have time to arrive rather than hitting the timeout and being recorded as silent drops

## Test plan

- [ ] Run `--suite=phishing-domains --size=S` — should now probe 50 domains and show meaningful blocked/allowed counts on the Security tab
- [ ] Verify blocked phishing domains appear as `blocked` (403 from proxy) rather than `dropped` (timeout)

https://claude.ai/code/session_01QiHkJ7DeFEB7bsfFW93bXW

---
_Generated by [Claude Code](https://claude.ai/code/session_01QiHkJ7DeFEB7bsfFW93bXW)_