### PR TITLE
fix: move Docker Hub login before QEMU and Buildx setup steps

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -14,17 +14,17 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Set up QEMU (for multi-arch emulation)
-        uses: docker/setup-qemu-action@v3
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
       - name: Log in to Docker Hub
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Set up QEMU (for multi-arch emulation)
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
       # Check whether jdibby/msf-base:latest already exists on Docker Hub.
       # On the very first run (or after a registry wipe) it won't — the next

--- a/.github/workflows/msf-base-publish.yml
+++ b/.github/workflows/msf-base-publish.yml
@@ -23,17 +23,17 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Set up QEMU (for multi-arch emulation)
-        uses: docker/setup-qemu-action@v3
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
       - name: Log in to Docker Hub
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Set up QEMU (for multi-arch emulation)
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
       - name: Build and push msf-base
         uses: docker/build-push-action@v6


### PR DESCRIPTION
## Summary

`setup-qemu-action` and `setup-buildx-action` both pull images from Docker Hub. They were running **before** `docker/login-action`, so those pulls were anonymous — hitting the free-tier rate limit even though the account is Pro.

Moving the login step to run immediately after checkout means all Docker Hub pulls (QEMU emulators, BuildKit, base images) are authenticated against the Pro account with no rate limit.

Applied to both `docker-publish.yml` and `msf-base-publish.yml`.

https://claude.ai/code/session_01QiHkJ7DeFEB7bsfFW93bXW

---
_Generated by [Claude Code](https://claude.ai/code/session_01QiHkJ7DeFEB7bsfFW93bXW)_