### PR TITLE
fix: round-robin deck in loop mode ensures every test runs before repeating

### DIFF
--- a/generator.py
+++ b/generator.py
@@ -2952,18 +2952,25 @@ def run_test(func_list: list) -> None:
     Execute `func_list` tests.
 
     * Non-loop mode: run each function once in shuffled order.
-    * Loop mode: pick a random function each iteration, run indefinitely,
-      kicking the watchdog after each test so it doesn't time out.
+    * Loop mode: cycle through the full list in a new random order each round,
+      guaranteeing every test runs once per round before any repeats.
     """
     ui_startup_banner()
     time.sleep(0.3)     # let the banner render before test output begins
 
     iteration = 0
     if ARGS.loop:
+        deck: list = []
+        round_num = 0
         while True:
+            if not deck:
+                round_num += 1
+                deck = func_list[:]
+                random.shuffle(deck)
+                console.rule(f"[dim]round {round_num} — {len(deck)} tests[/]")
+            func = deck.pop()
             iteration += 1
             console.rule(f"[dim]iteration {iteration}[/]")
-            func = random.choice(func_list)
             _run_guarded(func)
             WATCHDOG.kick()
             finish_test()


### PR DESCRIPTION
## Summary

In `--loop` mode `run_test` was calling `random.choice(func_list)` on every iteration. `random.choice` samples **with replacement**, so the same test could be selected many times in a row while other tests never ran — especially noticeable with `--suite=all` which has a large function list.

## Fix

Replaced with a **dealt-deck** (shuffle-and-exhaust) pattern:

1. At the start of each round, copy the full function list into a `deck` and shuffle it.
2. Pop one function per iteration.
3. When the deck is empty, start a new round (reshuffle).

Every test now runs **exactly once per round** before any test repeats, while the order within each round is still fully randomized. A `[dim]round N — X tests[/]` rule line is printed at the start of each round so it's visible in the log.

## Test plan

- [ ] Run `--suite=all --loop` and observe that `round 1 — N tests` appears, all tests run once, then `round 2` starts
- [ ] Confirm no single test dominates multiple consecutive iterations

https://claude.ai/code/session_01QiHkJ7DeFEB7bsfFW93bXW

---
_Generated by [Claude Code](https://claude.ai/code/session_01QiHkJ7DeFEB7bsfFW93bXW)_