### PR TITLE
feat: countdown timer in status pill during inter-test pause

### DIFF
--- a/generator.py
+++ b/generator.py
@@ -461,6 +461,7 @@ _WEB_STATE: dict = {
     "version": "", "started_at": 0.0, "suite": "all", "size": "S",
     "max_wait_secs": 20, "loop": True, "current_test": "", "iteration": 0,
     "status": "starting",   # running | between_tests | paused | stopped
+    "pause_until": 0.0,     # epoch seconds when current inter-test pause ends (0 = not pausing)
     "test_started_at": 0.0,
     "tests": {}, "suites": [],
     "totals": {"attempts": 0, "ok": 0, "fail": 0, "blocked": 0, "dropped": 0, "allowed": 0},
@@ -3023,10 +3024,15 @@ def finish_test() -> None:
     if not ARGS.nowait:
         if ARGS.loop:
             wait = random.randint(2, max(3, int(ARGS.max_wait_secs)))
-            progress_wait(wait, label="Pause between iterations")
         else:
             wait = random.randint(2, 5)
-            progress_wait(wait, label="Pause between tests")
+        with _WEB_STATE_LOCK:
+            _WEB_STATE["pause_until"] = time.time() + wait
+        _web_flush()
+        progress_wait(wait, label="Pause between iterations" if ARGS.loop else "Pause between tests")
+        with _WEB_STATE_LOCK:
+            _WEB_STATE["pause_until"] = 0.0
+        _web_flush()
     console.print("")   # visual separator in output
 
 

--- a/webui.py
+++ b/webui.py
@@ -1133,7 +1133,7 @@ const Tc=ts=>new Date(ts*1000).toLocaleTimeString([],{hour:'2-digit',minute:'2-d
 const Ts=ts=>new Date(ts*1000).toLocaleTimeString([],{hour:'2-digit',minute:'2-digit'});
 const Dur=ms=>ms<1000?ms+'ms':(ms/1000).toFixed(1)+'s';
 const RC=p=>p>=90?'var(--green)':p>=70?'var(--amber)':'var(--red)';
-let _start=null,_uptimer=null,_elTimer=null,_autoScroll=true;
+let _start=null,_uptimer=null,_elTimer=null,_pauseTimer=null,_autoScroll=true;
 let _lastState=null,_logEs=null,_logFilter='all';
 let _xRows=new Set(),_xEvs=new Set(),_modalSuite=null,_isPaused=false,_lastTest=null;
 let _isAdmin=true,_authRequired=false,_adminToken='',_sessionMode=false,_hasController=false;
@@ -1226,7 +1226,13 @@ function apply(s){
   if(s.started_at&&!_start){_start=s.started_at;clearInterval(_uptimer);_uptimer=setInterval(()=>$('s-uptime').textContent='up '+uptime(_start),1000);}
   const st=s.status||'starting';
   const pill=$('status-pill');pill.className='tp-pill '+(ST_CLS[st]||'tp-dim');
-  const dot=st==='running'||st==='starting';pill.innerHTML=(dot?'<span class="pulse"></span>':'')+(ST_LBL[st]||st);
+  clearInterval(_pauseTimer);_pauseTimer=null;
+  if(st==='between_tests'&&s.pause_until){
+    const renderCD=()=>{const rem=Math.max(0,Math.ceil(s.pause_until-Date.now()/1000));pill.textContent='Between Tests ('+rem+'s)';if(rem<=0){clearInterval(_pauseTimer);_pauseTimer=null;}};
+    renderCD();_pauseTimer=setInterval(renderCD,250);
+  } else {
+    const dot=st==='running'||st==='starting';pill.innerHTML=(dot?'<span class="pulse"></span>':'')+(ST_LBL[st]||st);
+  }
   _isPaused=(st==='paused');$('btn-pause').innerHTML=_isPaused?'&#9654;':'&#9208;';$('btn-pause').title=_isPaused?'Resume tests':'Pause tests';
   const lp=$('pill-live');if(st==='stopped'){lp.className='tp-pill tp-stopped';lp.innerHTML='&#9209; STOPPED';}else{lp.className='tp-pill tp-running';lp.innerHTML='<span class="pulse"></span>LIVE';}
   $('cfg-s-pill').textContent='suite:'+(s.suite||'—');$('cfg-z-pill').textContent='size:'+(s.size||'—');


### PR DESCRIPTION
## Summary

When the generator is pausing between tests the status pill now shows a live countdown: **Between Tests (12s)**, **Between Tests (11s)**, … down to 0.

### How it works

**`generator.py`** — `finish_test()` now publishes `pause_until` (Unix epoch timestamp when the pause ends) to `_WEB_STATE` and SSE-flushes it before calling `progress_wait()`. After the wait it clears `pause_until` back to `0.0` and flushes again. The console already shows a Rich progress bar with `TimeRemainingColumn` via `progress_wait()`.

**`webui.py`** — `apply(s)` checks for `st === 'between_tests'` with a non-zero `s.pause_until`. When present, a `_pauseTimer` interval fires every 250 ms and updates the status pill to `Between Tests (Xs)`. The 250 ms rate keeps the displayed second snappy without drift. The timer is cleared whenever the state transitions away from `between_tests`.

## Test plan
- [ ] Run `--suite=all --loop`; observe status pill counts down "Between Tests (Ns)" during each inter-test pause
- [ ] Confirm pill reverts to "Running" (with pulse dot) when the next test starts
- [ ] Confirm `--nowait` still works (no countdown, pill goes straight back to Running)

https://claude.ai/code/session_01QiHkJ7DeFEB7bsfFW93bXW

---
_Generated by [Claude Code](https://claude.ai/code/session_01QiHkJ7DeFEB7bsfFW93bXW)_