### PR TITLE
fix: correct default --size to S everywhere

### DIFF
--- a/generator.py
+++ b/generator.py
@@ -3165,8 +3165,8 @@ def parse_cli() -> argparse.Namespace:
         help=f"Test suite to run (default: all).  Choices:\n  {', '.join(suite_choices)}",
     )
     traffic.add_argument(
-        "--size", type=str.upper, choices=["XS", "S", "M", "L", "XL"], default="M",
-        help="Volume of traffic: XS=tiny  S=small  M=medium  L=large  XL=extra-large (default: M)",
+        "--size", type=str.upper, choices=["XS", "S", "M", "L", "XL"], default="S",
+        help="Volume of traffic: XS=tiny  S=small  M=medium  L=large  XL=extra-large (default: S)",
     )
 
     timing = parser.add_argument_group("Timing & Loop")

--- a/webui.py
+++ b/webui.py
@@ -1114,7 +1114,7 @@ docker run --pull=always -it jdibby/traffgen:latest --suite=dns --size=L</div>
         <table class="st-table">
           <tr><th>Flag</th><th>Values</th><th>Default</th><th>Description</th></tr>
           <tr><td>--suite</td><td style="color:var(--text)">any suite name</td><td>all</td><td>Test suite to run</td></tr>
-          <tr><td>--size</td><td style="color:var(--text)">XS S M L XL</td><td>XS</td><td>Traffic volume / intensity</td></tr>
+          <tr><td>--size</td><td style="color:var(--text)">XS S M L XL</td><td>S</td><td>Traffic volume / intensity</td></tr>
           <tr><td>--loop</td><td style="color:var(--text)">flag</td><td>off</td><td>Loop forever, random suite each iteration</td></tr>
           <tr><td>--max-wait-secs</td><td style="color:var(--text)">integer</td><td>20</td><td>Max pause between iterations</td></tr>
           <tr><td>--nowait</td><td style="color:var(--text)">flag</td><td>off</td><td>Skip all inter-test pauses</td></tr>
@@ -1176,7 +1176,7 @@ docker run --pull=always -it jdibby/traffgen:latest --suite=dns --size=L</div>
       <div>
         <div class="modal-sep" style="margin-bottom:10px">Run Configuration</div>
         <div class="field" style="margin-bottom:10px"><label>Size</label>
-          <select id="modal-size"><option value="XS">XS</option><option value="S">S</option><option value="M">M</option><option value="L">L</option><option value="XL">XL</option></select>
+          <select id="modal-size"><option value="XS">XS</option><option value="S" selected>S</option><option value="M">M</option><option value="L">L</option><option value="XL">XL</option></select>
         </div>
         <div class="field" style="margin-bottom:10px"><label>Max Wait</label>
           <div class="rngw"><input type="range" id="modal-wait" min="5" max="300" step="5" value="20" oninput="$('modal-wv').textContent=this.value+'s'"><span class="rngv" id="modal-wv">20s</span></div>


### PR DESCRIPTION
## Summary

The `--size` default was inconsistent across the codebase:
- README documented it as `S`
- `generator.py` argparse had `default="M"`
- Web UI CLI reference table showed `XS` as the default

This PR aligns everything to `S`:

- `generator.py`: `default="M"` → `default="S"`, help string updated
- `webui.py` CLI reference table: Default column `XS` → `S`
- `webui.py` launch modal: `S` option now has `selected` attribute

https://claude.ai/code/session_01QiHkJ7DeFEB7bsfFW93bXW

---
_Generated by [Claude Code](https://claude.ai/code/session_01QiHkJ7DeFEB7bsfFW93bXW)_