### PR TITLE
fix(health): network interfaces widget not populating + log viewer broken

### DIFF
--- a/webui.py
+++ b/webui.py
@@ -1377,7 +1377,7 @@ function showTab(btn){
   if(btn.dataset.tab==='output')connectLog();
   clearInterval(_healthTimer);_healthTimer=null;
   clearInterval(_secTimer);_secTimer=null;
-  if(btn.dataset.tab==='health'){pollHealth();_healthTimer=setInterval(pollHealth,2500);}
+  if(btn.dataset.tab==='health'){pollHealth();pollNetInfo();_healthTimer=setInterval(pollHealth,2500);}
   if(btn.dataset.tab==='security'){updateSecurityTab();_secTimer=setInterval(updateSecurityTab,_secInterval);}
 }
 function drawDonut(ok,fail){
@@ -1744,7 +1744,10 @@ function applyNetInfo(d){
   }).join('');
 }
 function pollNetInfo(){
-  fetch('/api/netinfo').then(r=>r.json()).then(d=>applyNetInfo(d)).catch(()=>{});
+  fetch('/api/netinfo')
+    .then(r=>{if(!r.ok)throw new Error('HTTP '+r.status);return r.json();})
+    .then(d=>applyNetInfo(d))
+    .catch(e=>{const tb=$('netinfo-body');if(tb)tb.innerHTML='<tr><td colspan="6" class="empty" style="color:var(--red)">Error: '+String(e)+'</td></tr>';});
 }
 pollNetInfo();
 setInterval(pollNetInfo,60000);
@@ -1972,7 +1975,6 @@ body{background:var(--bg);color:var(--text);font-family:'SF Mono',Consolas,monos
 <script>
 let as=true,lf='all',lt=null;
 const b=document.getElementById('body');
-const H=s=>String(s).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');
 const Tc=ts=>new Date(ts*1000).toLocaleTimeString([],{hour:'2-digit',minute:'2-digit',second:'2-digit'});
 function setF(btn,lvl){lf=lvl;document.querySelectorAll('.fgrp .btn').forEach(x=>x.classList.remove('af'));btn.classList.add('af');document.querySelectorAll('.ll').forEach(el=>{if(el.classList.contains('ll-sep'))return;el.style.display=(lvl==='all'||el.classList.contains(lvl))?'':'none';});}
 const es=new EventSource('/log');


### PR DESCRIPTION
## Fixes

**1. Network interfaces widget never populated on Health tab**
`pollNetInfo()` was called once on page load and every 60 s via `setInterval`, but was NOT called when the user navigated to the Health tab. If the user loaded the page on the Overview tab, the initial call happened before the backend thread had populated the cache, and by the time the user switched to Health the widget showed stale "Loading…". Added `pollNetInfo()` to `showTab()` alongside `pollHealth()`.

**2. Fetch errors were silently swallowed**
`.catch(()=>{})` meant any HTTP error or JSON parse failure was invisible. Changed to show the error string in the table body so it's visible without opening DevTools.

**3. Duplicate `const H` broke the log-viewer script block**
The log-viewer `<script>` block re-declared `const H` which was already declared `const` in the main `<script>` block. This is a `SyntaxError: Identifier 'H' has already been declared` that killed the entire second script block (log streaming). Removed the redundant declaration — `H` is already in scope from the first block.

https://claude.ai/code/session_01QiHkJ7DeFEB7bsfFW93bXW

---
_Generated by [Claude Code](https://claude.ai/code/session_01QiHkJ7DeFEB7bsfFW93bXW)_