### PR TITLE
fix(health): netinfo widget blank — interfaces blocked behind slow public-IP curl

### DIFF
--- a/webui.py
+++ b/webui.py
@@ -361,16 +361,21 @@ def _sample_net_info() -> None:
                     "link":  link,
                 })
 
-            # Refresh public IP on first run and every TTL seconds
-            if not public_ip or now - public_ip_ts >= PUBLIC_IP_TTL:
-                public_ip    = _fetch_public_ip()
-                public_ip_ts = now
-
+            # Push interfaces immediately so the widget has data before the
+            # public IP curl completes (which can take several seconds).
             with _net_info_lock:
                 _net_info_cache.update({
                     "interfaces": ifaces,
-                    "public_ip":  public_ip,
+                    "public_ip":  public_ip or "resolving…",
                 })
+
+            # Refresh public IP on first run and every TTL seconds — done
+            # after the cache update so it doesn't block interface display.
+            if not public_ip or now - public_ip_ts >= PUBLIC_IP_TTL:
+                public_ip    = _fetch_public_ip()
+                public_ip_ts = now
+                with _net_info_lock:
+                    _net_info_cache["public_ip"] = public_ip
         except Exception:
             pass
 


### PR DESCRIPTION
## Root cause

`_sample_net_info` collected interfaces and then called `_fetch_public_ip()` before writing **anything** to `_net_info_cache`. Each curl service has a 6 s `--max-time`, and all three are tried in sequence, so the first cache update could be delayed up to **~24 seconds** after thread start. Every `pollNetInfo()` call during that window received `{}` → widget showed "Loading…" / "No interfaces" indefinitely.

## Fix

Write the interface data to the cache **immediately** after it's collected, using `"resolving…"` as the `public_ip` placeholder. Then perform the WAN IP lookup and update only that field once the curl finishes. The widget now populates within ~2 s of container start; the public IP fills in once the external lookup returns.

```
Before: collect ifaces → fetch WAN IP (up to 24 s) → update cache
After:  collect ifaces → update cache → fetch WAN IP → update cache[public_ip]
```

https://claude.ai/code/session_01QiHkJ7DeFEB7bsfFW93bXW

---
_Generated by [Claude Code](https://claude.ai/code/session_01QiHkJ7DeFEB7bsfFW93bXW)_