### PR TITLE
fix: default security page refresh to 1s, matching live view speed

### DIFF
--- a/webui.py
+++ b/webui.py
@@ -1078,8 +1078,8 @@ body.ro-mode .ro-ctrl{opacity:.32;cursor:not-allowed}
         <div class="cc">
           <div class="ctitle">Outcome Distribution
             <select class="net-interval" onchange="setSecInterval(+this.value)" title="Summary refresh interval" id="sec-interval-sel">
-              <option value="30000">30s</option><option value="60000" selected>1m</option>
-              <option value="120000">2m</option><option value="300000">5m</option>
+              <option value="1000" selected>1s</option><option value="5000">5s</option>
+              <option value="30000">30s</option><option value="60000">1m</option>
             </select>
           </div>
           <div class="sec-donut-wrap">
@@ -1817,7 +1817,7 @@ function pollNetInfo(){
 pollNetInfo();
 setInterval(pollNetInfo,30000);
 // ── Security Summary ──────────────────────────────────────────────────────────
-let _secTimer=null,_secInterval=60000,_secHist=[];
+let _secTimer=null,_secInterval=1000,_secHist=[];
 function drawSecDonut(allowed,blocked,dropped,other){
   const c=$('sec-donut');if(!c)return;
   const ctx=c.getContext('2d'),W=c.width,H2=c.height,cx=W/2,cy=H2/2,r=66,ri=46;


### PR DESCRIPTION
## Summary

- Change `_secInterval` JS default from 60000ms to 1000ms so Security tab refreshes at 1s on load
- Update the interval selector to offer `1s` (default), `5s`, `30s`, `1m` instead of `30s`, `1m`, `2m`, `5m`

## Fixes

Security page donut chart and tables now update in real-time at the same cadence as the Live View page. Users can still slow it down via the dropdown if desired.

https://claude.ai/code/session_01QiHkJ7DeFEB7bsfFW93bXW

---
_Generated by [Claude Code](https://claude.ai/code/session_01QiHkJ7DeFEB7bsfFW93bXW)_