### PR TITLE
feat: stager.sh — run apt update && apt upgrade before Docker install

### DIFF
--- a/stager.sh
+++ b/stager.sh
@@ -160,6 +160,29 @@ esac
 
 ok "Detected: ${OS_LABEL}"
 
+# ── System package update & upgrade ──────────────────────────────────────────
+step "Updating and upgrading system packages"
+
+case "$PKG_FAMILY" in
+    deb)
+        export DEBIAN_FRONTEND=noninteractive
+        export NEEDRESTART_MODE=a
+        apt-get -qq update
+        apt-get -qq -y upgrade
+        ;;
+    rpm-rhel)
+        dnf -y -q upgrade
+        ;;
+    rpm-amzn)
+        if [ "${VERSION_ID:-}" = "2" ]; then
+            yum -y -q update
+        else
+            dnf -y -q upgrade
+        fi
+        ;;
+esac
+ok "System packages up to date"
+
 # ── Docker install (idempotent) ───────────────────────────────────────────────
 step "Checking Docker"
 


### PR DESCRIPTION
Adds an explicit system update/upgrade step after OS detection and before Docker install: `apt-get update && apt-get upgrade` for Debian/Ubuntu/Raspbian, `dnf upgrade` for RHEL-family and Amazon Linux 2023, `yum update` for Amazon Linux 2. Runs unconditionally to ensure the host is on current packages.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QiHkJ7DeFEB7bsfFW93bXW)_