### PR TITLE
feat: lateral movement — HOST_LAN_IP injected by stager.sh, --network=host as alternative

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,16 @@ The `lateral-movement` suite scans the **host's physical LAN**, not the Docker b
 
 #### Method 1 — stager.sh (recommended)
 
-`stager.sh` captures the host's LAN IP with `hostname -I` **before** the container starts and passes it in via `-e HOST_LAN_IP=<ip>`. The suite reads this env var and derives the /24 to scan. No extra flags needed — just use stager.sh.
+`stager.sh` captures the host's LAN IP **and subnet prefix** with `hostname -I` and `ip addr` **before** the container starts and passes them as `-e HOST_LAN_CIDR=<ip>/<prefix>`. The suite reads this and scans the correct network:
+
+| Host prefix | Scan target | Notes |
+|---|---|---|
+| `/24` | `x.x.x.0/24` | Normal LAN |
+| `/25` – `/31` | Actual subnet | Smaller segment |
+| `/32` | `x.x.x.0/24` | **Microsegmentation detected** — suite logs a warning and scans the containing /24 to probe east-west policy |
+| `/8` – `/23` | `x.x.x.0/24` | Large subnet capped at /24 to keep scan time reasonable |
+
+No extra flags needed — just use stager.sh.
 
 #### Method 2 — `--network=host`
 

--- a/README.md
+++ b/README.md
@@ -156,7 +156,31 @@ The dashboard includes:
 | 🏢 `shadow-it` | HEAD requests to **27 unsanctioned cloud applications** across five CASB app-control categories: personal file sharing (Dropbox, Box, MEGA, WeTransfer, OneDrive consumer, iCloud), personal messaging (Discord, Telegram, WhatsApp Web), privacy/anonymising mail (ProtonMail, Tutanota, Guerrilla Mail), paste/file hosting (Pastebin, Filebin, GoFile), and crypto/blockchain (Coinbase, Etherscan, Binance). Tests CASB app-control and SSE category blocking policies for unsanctioned cloud usage. |
 | 📤 `data-exfil-http` | POSTs **synthetic PII and credential payloads** to public paste and file-drop services (Pastebin, Hastebin, Paste2, transfer.sh, Filebin). Payload types: US Social Security Number lists, payment card numbers (Luhn-valid), RSA private key blocks, password hashes, and CSV PII. Tests DLP outbound content-inspection (Zscaler DLP, Netskope DLP, Palo Alto Enterprise DLP) and CASB upload policies — all destinations return 4xx but the outbound POST bodies are visible to inline inspection. |
 | 🔐 `tls-check` | Connects to **20 diverse HTTPS endpoints** (CDN, cloud, social, developer tools, finance, government) and reports the presented TLS certificate for each: Subject CN, Issuer CN + Org, expiry, SHA-256 fingerprint, and verification status. Classifies each host as **CLEAN** (original cert received), **INTERCEPTED** (issuer matches a known SASE/SSE/proxy vendor CA — Zscaler, Netskope, Palo Alto, Fortinet, Cato, Cisco, Blue Coat, Forcepoint, iboss, and others), **UNVERIFIED** (proxy is re-signing but the CA is not installed in the container), or **UNREACHABLE**. Also detects shared-CA fingerprints across unrelated sites (a reliable proxy signal even when the vendor name is unrecognised). Reports selective bypass: if finance/government hosts are CLEAN while social/developer hosts are INTERCEPTED, the proxy has category or ASN bypass rules active. Use `EXTRA_CA_CERT` or a bind-mounted `.crt` file to install the proxy CA if seeing UNVERIFIED results. |
-| 🔀 `lateral-movement` | Two-phase east-west reconnaissance against the Docker host's **physical LAN** (not the Docker bridge). The real LAN is detected automatically: first by scanning the routing table for non-bridge RFC1918 connected subnets, then via traceroute — skipping 172.16–31.x docker hops — to find the actual LAN gateway. **Phase 1:** nmap `-sn` ping sweep of the entire **/24** — enumerates all live hosts. **Phase 2:** port scan every discovered host on **12 lateral-movement ports**: SSH (22), Kerberos (88), WMI/RPC (135), NetBIOS (137-139), LDAP (389), SMB (445), LDAPS (636), RDP (3389), WinRM HTTP/HTTPS (5985/5986). Per-host results are classified and recorded for the security dashboard — `open` ports → `allowed`, TCP RST → `blocked`, silently dropped → `dropped`. Tests east-west NGFW policies (Palo Alto, Fortinet), SIEM lateral-movement correlation rules, and network IDS SMB/RDP recon signatures. |
+| 🔀 `lateral-movement` | Two-phase east-west reconnaissance against the Docker **host's physical LAN**. ⚠️ **Requires one of the two methods below** to reach the real LAN — see [Lateral Movement networking](#-lateral-movement-networking) for details. **Phase 1:** nmap `-sn` ping sweep of the entire **/24** — enumerates all live hosts. **Phase 2:** port scan every discovered host on **12 lateral-movement ports**: SSH (22), Kerberos (88), WMI/RPC (135), NetBIOS (137-139), LDAP (389), SMB (445), LDAPS (636), RDP (3389), WinRM HTTP/HTTPS (5985/5986). Per-host results classified and recorded — `open` → `allowed`, TCP RST → `blocked`, silently dropped → `dropped`. Tests east-west NGFW policies (Palo Alto, Fortinet), SIEM lateral-movement correlation rules, and network IDS SMB/RDP recon signatures. |
+
+---
+
+### 🔀 Lateral Movement Networking
+
+The `lateral-movement` suite scans the **host's physical LAN**, not the Docker bridge (`172.17.x.x`). A standard Docker container runs in its own network namespace and cannot see the host's physical interfaces. One of the following two methods is required:
+
+#### Method 1 — stager.sh (recommended)
+
+`stager.sh` captures the host's LAN IP with `hostname -I` **before** the container starts and passes it in via `-e HOST_LAN_IP=<ip>`. The suite reads this env var and derives the /24 to scan. No extra flags needed — just use stager.sh.
+
+#### Method 2 — `--network=host`
+
+Run the container with `--network=host` to share the host's network namespace. The container can then see and scan the host's physical interfaces directly.
+
+```bash
+docker run --pull=always --detach --restart unless-stopped \
+  -p 7777:7777 --network=host --name traffgen jdibby/traffgen:latest \
+  --suite=all --size=S --max-wait-secs=20 --loop
+```
+
+> **Note:** `--network=host` is Linux-only. It does not work on Docker Desktop for Mac or Windows.
+
+If neither method is used, the suite logs a warning and falls back to scanning the container's own subnet (useful only for inter-container east-west testing).
 
 ---
 

--- a/generator.py
+++ b/generator.py
@@ -3711,27 +3711,32 @@ def _detect_host_lan() -> "tuple[str, str] | None":
     """Return (gateway_ip, subnet/24) for the physical LAN the Docker host uses.
 
     Strategies (tried in order):
-      1. Parse /proc/net/route — no external tools required. Finds connected
-         routes (gateway=0.0.0.0, flags RTF_UP) on non-loopback interfaces,
-         skipping docker bridge (172.16-31.x) and loopback (127.x).
-         Falls back to the default-route gateway's /24 if no connected
-         non-docker subnet is found.
+      0. HOST_LAN_IP env var — set by stager.sh before the container starts
+         using ``hostname -I`` on the host.  Most reliable: the host resolves
+         its own IP before Docker networking is involved at all.
+      1. Parse /proc/net/route — no external tools required.
       2. ``ip route show`` — for environments where ip(8) is available.
-      3. Traceroute to 8.8.8.8, take first non-docker hop (no RFC1918 filter
-         since lab environments may use non-standard ranges).
+      3. Traceroute to 8.8.8.8, take first non-docker hop.
     """
+    import os as _os
     import socket as _socket
     import struct as _struct
     import re as _re
 
     _LOOPBACK = _re.compile(r"^127\.")
     _DOCKER_BRIDGE = _re.compile(r"^172\.(1[6-9]|2[0-9]|3[01])\.")
+    _IP_RE = _re.compile(r"^\d{1,3}(?:\.\d{1,3}){3}$")
 
     def _hex_to_ip(h: str) -> str:
         return _socket.inet_ntoa(_struct.pack("<I", int(h, 16)))
 
     def _to_24(ip: str) -> str:
         return ".".join(ip.split(".")[:3]) + ".0/24"
+
+    # Strategy 0 — HOST_LAN_IP env var injected by stager.sh before container start
+    _env_ip = _os.environ.get("HOST_LAN_IP", "").strip()
+    if _env_ip and _IP_RE.match(_env_ip):
+        return _env_ip, _to_24(_env_ip)
 
     # Strategy 1 — /proc/net/route (no tools needed, works in any container)
     try:
@@ -3838,9 +3843,10 @@ def lateral_movement_sim() -> None:
         _stats.fail()
         return
     gw_ip, subnet = lan
+    _src = "HOST_LAN_IP env" if os.environ.get("HOST_LAN_IP", "").strip() else "auto-detected"
 
     ui_banner("Lateral Movement Simulation",
-              f"gateway={gw_ip}  subnet={subnet}  ports={_LATERAL_PORTS}")
+              f"gateway={gw_ip}  subnet={subnet}  source={_src}  ports={_LATERAL_PORTS}")
 
     # ── Phase 1: ping sweep ──────────────────────────────────────────────────
     console.log(f"[cyan]Phase 1[/] ping sweep → {subnet}")

--- a/generator.py
+++ b/generator.py
@@ -3733,10 +3733,25 @@ def _detect_host_lan() -> "tuple[str, str] | None":
     def _to_24(ip: str) -> str:
         return ".".join(ip.split(".")[:3]) + ".0/24"
 
-    # Strategy 0 — HOST_LAN_IP env var injected by stager.sh before container start
-    _env_ip = _os.environ.get("HOST_LAN_IP", "").strip()
-    if _env_ip and _IP_RE.match(_env_ip):
-        return _env_ip, _to_24(_env_ip)
+    # Strategy 0 — HOST_LAN_CIDR env var injected by stager.sh before container start
+    _env_cidr = _os.environ.get("HOST_LAN_CIDR", "").strip()
+    if _env_cidr and "/" in _env_cidr:
+        _eip, _epfx = _env_cidr.split("/", 1)
+        if _IP_RE.match(_eip) and _epfx.isdigit():
+            _prefix = int(_epfx)
+            if _prefix == 32:
+                # Every host is its own /32 — microsegmentation is on.
+                # Scan the containing /24 to probe east-west policy.
+                return _eip, _to_24(_eip)
+            elif _prefix >= 24:
+                # Use actual subnet (/24, /25, /26, /28, etc.)
+                import ipaddress as _ipaddress
+                _net = str(_ipaddress.ip_network(f"{_eip}/{_prefix}", strict=False))
+                return _eip, _net
+            else:
+                # Subnet larger than /24 (/16, /8, etc.) — cap at /24 to keep
+                # scan time reasonable (a /16 is 65535 hosts).
+                return _eip, _to_24(_eip)
 
     # Strategy 1 — /proc/net/route (no tools needed, works in any container)
     try:
@@ -3843,7 +3858,12 @@ def lateral_movement_sim() -> None:
         _stats.fail()
         return
     gw_ip, subnet = lan
-    _src = "HOST_LAN_IP env" if os.environ.get("HOST_LAN_IP", "").strip() else "auto-detected"
+    _cidr = os.environ.get("HOST_LAN_CIDR", "").strip()
+    _src = "stager.sh" if _cidr else "auto-detected"
+    _microseg = _cidr.endswith("/32")
+
+    if _microseg:
+        ui_warn("Microsegmentation detected (host prefix /32) — scanning /24 to probe east-west policy")
 
     ui_banner("Lateral Movement Simulation",
               f"gateway={gw_ip}  subnet={subnet}  source={_src}  ports={_LATERAL_PORTS}")

--- a/stager.sh
+++ b/stager.sh
@@ -298,20 +298,31 @@ docker pull jdibby/traffgen:latest
 
 step "Starting traffgen container"
 
-# Capture the host's LAN IP before the container starts so the lateral-movement
-# suite can scan the real physical network rather than the Docker bridge.
+# Capture the host's LAN IP and subnet prefix before the container starts.
+# This lets the lateral-movement suite scan the real physical network.
+# We grab both the IP and the prefix length (/24, /32, etc.) so the scanner
+# knows the actual network size.  If the prefix is /32 (microsegmentation),
+# the suite will assume /24 and note that microsegmentation is detected.
 HOST_LAN_IP=$(hostname -I 2>/dev/null | awk '{print $1}')
+HOST_LAN_CIDR=""
 if [ -n "$HOST_LAN_IP" ]; then
-    ok "Host LAN IP detected: ${HOST_LAN_IP} (will be passed to container for lateral movement)"
+    _PREFIX=24  # safe default
+    if command -v ip >/dev/null 2>&1; then
+        _P=$(ip -o -f inet addr 2>/dev/null \
+             | awk -v h="$HOST_LAN_IP" 'index($4, h"/")>0 {split($4,a,"/"); print a[2]; exit}')
+        [ -n "$_P" ] && _PREFIX="$_P"
+    fi
+    HOST_LAN_CIDR="${HOST_LAN_IP}/${_PREFIX}"
+    ok "Host LAN detected: ${HOST_LAN_CIDR} (passed to container for lateral movement)"
 else
-    echo "WARNING: could not detect host LAN IP — lateral-movement suite will fall back to container network"
+    echo "WARNING: could not detect host LAN — lateral-movement suite will fall back to container network"
 fi
 
 docker run \
     --detach \
     --restart unless-stopped \
     -p 7777:7777 \
-    ${HOST_LAN_IP:+-e HOST_LAN_IP="$HOST_LAN_IP"} \
+    ${HOST_LAN_CIDR:+-e HOST_LAN_CIDR="$HOST_LAN_CIDR"} \
     --name traffgen \
     jdibby/traffgen:latest \
     --suite=all --size=S --max-wait-secs=20 --loop

--- a/stager.sh
+++ b/stager.sh
@@ -297,10 +297,21 @@ step "Pulling latest traffgen image"
 docker pull jdibby/traffgen:latest
 
 step "Starting traffgen container"
+
+# Capture the host's LAN IP before the container starts so the lateral-movement
+# suite can scan the real physical network rather than the Docker bridge.
+HOST_LAN_IP=$(hostname -I 2>/dev/null | awk '{print $1}')
+if [ -n "$HOST_LAN_IP" ]; then
+    ok "Host LAN IP detected: ${HOST_LAN_IP} (will be passed to container for lateral movement)"
+else
+    echo "WARNING: could not detect host LAN IP — lateral-movement suite will fall back to container network"
+fi
+
 docker run \
     --detach \
     --restart unless-stopped \
     -p 7777:7777 \
+    ${HOST_LAN_IP:+-e HOST_LAN_IP="$HOST_LAN_IP"} \
     --name traffgen \
     jdibby/traffgen:latest \
     --suite=all --size=S --max-wait-secs=20 --loop


### PR DESCRIPTION
Solves the fundamental problem of scanning the host's physical LAN from inside a Docker container.

**stager.sh** captures `hostname -I` before `docker run` and passes `-e HOST_LAN_IP=<ip>` to the container. `_detect_host_lan()` checks this env var first (strategy 0) — zero in-container detection needed, guaranteed to reflect the host's real LAN.

**`--network=host`** documented as the alternative for users running `docker run` manually.

**README** gets a new "Lateral Movement Networking" section explaining both methods and why standard bridge mode can't reach the host LAN.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QiHkJ7DeFEB7bsfFW93bXW)_