### PR TITLE
Test name consistency: use suite key (dash format) everywhere

### DIFF
--- a/generator.py
+++ b/generator.py
@@ -826,14 +826,15 @@ def _run_guarded(func) -> None:
     """
     limit = _SUITE_TIMEOUTS.get(func.__name__, 120)
     exc_box: list[BaseException] = []
+    suite_name = _FUNC_TO_SUITE.get(func.__name__, func.__name__)
 
     _stats.reset(func.__name__)
     with _WEB_STATE_LOCK:
-        _WEB_STATE["current_test"]    = func.__name__
+        _WEB_STATE["current_test"]    = suite_name
         _WEB_STATE["test_started_at"] = time.time()
         _WEB_STATE["status"]          = "running"
     _web_flush()
-    _web_log(f"Starting {func.__name__}", level="info", test=func.__name__)
+    _web_log(f"Starting {suite_name}", level="info", test=suite_name)
     t0 = time.time()
 
     def _wrapper() -> None:
@@ -846,20 +847,20 @@ def _run_guarded(func) -> None:
     t.start()
     t.join(timeout=limit)
     if t.is_alive():
-        ui_warn(f"[guard] {func.__name__} exceeded {limit}s — advancing to next test")
+        ui_warn(f"[guard] {suite_name} exceeded {limit}s — advancing to next test")
     elif exc_box:
-        ui_error(f"[{func.__name__}] {exc_box[0]}")
+        ui_error(f"[{suite_name}] {exc_box[0]}")
 
     _stats.print_summary()
     dur_ms = int((time.time() - t0) * 1000)
     run_ok = not exc_box and not t.is_alive()
-    _web_record(func.__name__, run_ok, dur_ms, _stats.responses, dict(_stats.codes),
+    _web_record(suite_name, run_ok, dur_ms, _stats.responses, dict(_stats.codes),
                 blocked=_stats.blocked, dropped=_stats.dropped, allowed=_stats.allowed)
     _web_log(
-        f"{func.__name__}: {_stats.attempts} attempts, "
+        f"{suite_name}: {_stats.attempts} attempts, "
         f"{_stats.responses} ok, {_stats.errors} fail — {dur_ms}ms",
         level="ok" if run_ok else "warn",
-        test=func.__name__,
+        test=suite_name,
     )
 
 
@@ -3998,6 +3999,14 @@ _SUITE_MAP: dict[str, list] = {
     "waf-attack":       [waf_attack],
     "data-exfil-http":  [data_exfil_http],
     "web-scanner":      [web_scanner],
+}
+
+
+# Reverse map: Python function name → suite key (e.g. "lateral_movement_sim" → "lateral-movement")
+_FUNC_TO_SUITE: dict[str, str] = {
+    f.__name__: suite
+    for suite, funcs in _SUITE_MAP.items()
+    for f in funcs
 }
 
 

--- a/webui.py
+++ b/webui.py
@@ -1543,7 +1543,7 @@ function apply(s){
   $('v-total').textContent=N(att);$('s-total').textContent=N(ok)+' ok \xb7 '+N(fail)+' fail'+(blk?' \xb7 '+N(blk)+' blocked':'')+(drp?' \xb7 '+N(drp)+' dropped':'');
   $('v-rate').textContent=att?p.toFixed(1)+'%':'—';$('v-rate').style.color=att?RC(p):'var(--muted)';$('s-rate').textContent=att?N(att)+' total requests':'No data yet';
   const cur=s.current_test||'',tsa=s.test_started_at||0;
-  $('v-test').textContent=cur?cur.replace(/_/g,' '):'—';
+  $('v-test').textContent=cur?cur.replace(/-/g,' '):'—';
   if(tsa&&cur){clearInterval(_elTimer);const upEl=()=>$('s-test').textContent=elapsed(tsa);upEl();_elTimer=setInterval(upEl,1000);}
   else{clearInterval(_elTimer);$('s-test').textContent=s.loop?'Loop mode':'Single-run';}
   $('v-iter').textContent=s.iteration?'#'+N(s.iteration):'—';$('s-iter').textContent='Suite: '+(s.suite||'—')+' \xb7 Size: '+(s.size||'—');
@@ -1559,7 +1559,7 @@ function apply(s){
     const ctags=Object.entries(codes).sort().map(([k,v])=>`<span class="ctag">${H(k)}: ${N(v)}</span>`).join('');
     return`<tr class="mrow${act?' style="background:rgba(34,197,94,.04)"':''}" onclick="toggleRow('${n}')">
       <td><span class="chev${exp?' open':''}">&#8250;</span></td>
-      <td class="nm"><span class="s-ico">${suiteIco(n)}</span>${act?'<span style="color:var(--green)">&#9654; </span>':''}${H(n.replace(/_/g,' '))}</td>
+      <td class="nm"><span class="s-ico">${suiteIco(n)}</span>${act?'<span style="color:var(--green)">&#9654; </span>':''}${H(n.replace(/-/g,' '))}</td>
       <td class="r">${N(ta)}</td><td class="r" style="color:var(--green)">${N(tok)}</td>
       <td class="r" style="color:${tf?'var(--red)':'var(--muted)'}">${N(tf)}</td>
       <td class="r"><div class="rw"><span style="color:${bc}">${ta?tp.toFixed(1)+'%':'—'}</span><div class="bt"><div class="bf" style="width:${tp}%;background:${bc}"></div></div></div></td>
@@ -1582,7 +1582,7 @@ function apply(s){
     const codes=e.codes&&Object.keys(e.codes).length?Object.entries(e.codes).sort().map(([k,v])=>k+':'+v).join(' \xb7 '):'';
     return`<div class="ev-wrap" onclick="toggleEv(${i})"><div class="evrow">
       <span class="et">${Tc(e.t)}</span>
-      <span style="overflow:hidden;text-overflow:ellipsis;white-space:nowrap">${H((e.test||'').replace(/_/g,' '))}</span>
+      <span style="overflow:hidden;text-overflow:ellipsis;white-space:nowrap">${H((e.test||'').replace(/-/g,' '))}</span>
       <span class="${e.ok?'eok':'efail'}">${e.ok?'✓ OK':'✗ FAIL'}</span>
       <span class="edur">${e.dur_ms!=null?Dur(e.dur_ms):'—'}</span>
       <span class="echev${exp?' open':''}">&#8250;</span>
@@ -1596,7 +1596,7 @@ function apply(s){
     const td=tests[su.name]||{},ta=td.attempts||0,tok=td.ok||0,tf=td.fail||0,tp=ta?tok/ta*100:0;
     const bc=RC(tp),act=su.name===cur;
     return`<div class="tcard2${act?' running':''}" data-suite="${H(su.name)}" data-desc="${H(su.description||'')}" onclick="openModal(this.dataset.suite,this.dataset.desc)">
-      <div class="tcn"><span class="s-ico">${suiteIco(su.name)}</span>${H(su.name.replace(/_/g,' '))}${act?'<span class="badge">RUNNING</span>':''}</div>
+      <div class="tcn"><span class="s-ico">${suiteIco(su.name)}</span>${H(su.name.replace(/-/g,' '))}${act?'<span class="badge">RUNNING</span>':''}</div>
       <div class="tcd">${H(su.description||'—')}</div>
       <div class="tcs"><span style="color:var(--muted)">${N(ta)} attempts</span><span style="color:var(--green)">${N(tok)} ok</span><span style="color:${tf?'var(--red)':'var(--muted)'}">${N(tf)} fail</span>${ta?'<span style="color:'+bc+'">'+tp.toFixed(1)+'%</span>':''}</div>
       ${ta?`<div class="tcbar"><div class="tcbf" style="width:${tp}%;background:${bc}"></div></div>`:''}
@@ -1645,7 +1645,7 @@ function appendLog(d){
   if(test&&test!==_lastTest){
     _lastTest=test;
     const sep=document.createElement('div');sep.className='ll ll-sep';
-    sep.innerHTML=`<div class="sep-line"></div><div class="sep-txt">${H(test.replace(/_/g,' '))}</div><div class="sep-line"></div>`;
+    sep.innerHTML=`<div class="sep-line"></div><div class="sep-txt">${H(test.replace(/-/g,' '))}</div><div class="sep-line"></div>`;
     b.appendChild(sep);
   }
   const div=document.createElement('div');
@@ -1733,7 +1733,7 @@ function stopTests(){
 }
 function handleLiveClick(){if(_lastState&&_lastState.status==='stopped'){toast('Tests are already stopped',false);return;}stopTests();}
 function openModal(name,desc){
-  _modalSuite=name;$('modal-name').textContent=name.replace(/_/g,' ');$('modal-desc').textContent=desc||'No description available.';
+  _modalSuite=name;$('modal-name').textContent=name.replace(/-/g,' ');$('modal-desc').textContent=desc||'No description available.';
   const td=(_lastState&&_lastState.tests&&_lastState.tests[name])||{};
   const ta=td.attempts||0,tok=td.ok||0,tf=td.fail||0;
   $('ms-att').textContent=ta?N(ta):'—';$('ms-ok').textContent=tok?N(tok):'—';$('ms-fail').textContent=tf?N(tf):'—';
@@ -1970,7 +1970,7 @@ function updateSecurityTab(){
     const bp=r.tot?r.blk/r.tot*100:0,dp=r.tot?r.drp/r.tot*100:0;
     const bpC=bp>50?'var(--red)':bp>10?'var(--amber)':'var(--muted)';
     const dpC=dp>50?'var(--red)':dp>10?'#818cf8':'var(--muted)';
-    return`<tr class="mrow"><td class="nm"><span class="s-ico">${suiteIco(r.n)}</span>${H(r.n.replace(/_/g,' '))}</td><td class="r">${N(r.tot)}</td><td class="r" style="color:#22c55e">${N(r.rch)}</td><td class="r" style="color:var(--amber)">${N(r.blk)}</td><td class="r" style="color:#818cf8">${N(r.drp)}</td><td class="r"><span style="color:${bpC}">${r.tot?bp.toFixed(1)+'%':'—'}</span></td><td class="r"><span style="color:${dpC}">${r.tot?dp.toFixed(1)+'%':'—'}</span></td></tr>`;
+    return`<tr class="mrow"><td class="nm"><span class="s-ico">${suiteIco(r.n)}</span>${H(r.n.replace(/-/g,' '))}</td><td class="r">${N(r.tot)}</td><td class="r" style="color:#22c55e">${N(r.rch)}</td><td class="r" style="color:var(--amber)">${N(r.blk)}</td><td class="r" style="color:#818cf8">${N(r.drp)}</td><td class="r"><span style="color:${bpC}">${r.tot?bp.toFixed(1)+'%':'—'}</span></td><td class="r"><span style="color:${dpC}">${r.tot?dp.toFixed(1)+'%':'—'}</span></td></tr>`;
   }).join('');
   // block signal breakdown — aggregate codes across all tests
   const codeTotals={};
@@ -2141,7 +2141,7 @@ es.onmessage=ev=>{
   try{
     const d=JSON.parse(ev.data),lvl=d.level||'info';
     const test=d.test||'';
-    if(test&&test!==lt){lt=test;const sep=document.createElement('div');sep.className='ll ll-sep';sep.innerHTML='<div class="sep-line"></div><div class="sep-txt">'+H(test.replace(/_/g,' '))+'</div><div class="sep-line"></div>';b.appendChild(sep);}
+    if(test&&test!==lt){lt=test;const sep=document.createElement('div');sep.className='ll ll-sep';sep.innerHTML='<div class="sep-line"></div><div class="sep-txt">'+H(test.replace(/-/g,' '))+'</div><div class="sep-line"></div>';b.appendChild(sep);}
     const div=document.createElement('div');div.className='ll '+lvl;
     div.innerHTML='<span class="llt">'+Tc(d.t||Date.now()/1000)+'</span><span class="llv">'+H(lvl.toUpperCase().slice(0,5).padEnd(5))+'</span><span class="llm">'+H(d.msg||'')+'</span>';
     if(lf!=='all'&&!div.classList.contains(lf))div.style.display='none';


### PR DESCRIPTION
## Summary
- Add `_FUNC_TO_SUITE` reverse map built from `_SUITE_MAP` (e.g. `lateral_movement_sim` → `lateral-movement`)
- `_run_guarded()` now looks up the suite key name and uses it for `current_test`, `_web_record()`, and `_web_log()` instead of the Python function name
- `webui.py`: all `replace(/_/g,' ')` → `replace(/-/g,' ')` so dash-format names display with spaces consistently on every page

## Test plan
- [ ] Security page shows `lateral movement` (not `lateral movement sim` or `lateral_movement_sim`)
- [ ] Tests page shows `lateral-movement` key, which displays as `lateral movement`
- [ ] Live View separator shows correct suite name during run
- [ ] TEST BREAKDOWN and LIVE EVENTS both show the same name for each suite

---
_Generated by [Claude Code](https://claude.ai/code/session_01QiHkJ7DeFEB7bsfFW93bXW)_