### PR TITLE
Block &amp; Drop Trend: hover tooltip showing values at each data point

### DIFF
--- a/webui.py
+++ b/webui.py
@@ -2054,6 +2054,12 @@ wireTip('h-net-spark',10,6,()=>_hNetHist,p=>[
   `<span style="color:var(--green)">▼ RX&nbsp;&nbsp;${fmtIO(p.rx||0)}</span>`,
   `<span style="color:var(--blue)">▲ TX&nbsp;&nbsp;${fmtIO(p.tx||0)}</span>`
 ]);
+wireTip('sec-trend',36,10,()=>_secHist,p=>[
+  `<span style="color:var(--muted)">${Tc(p.t)}</span>`,
+  `<span style="color:#f59e0b">⬛ Block&nbsp;&nbsp;${p.block_pct!=null?p.block_pct.toFixed(1)+'%':'—'}</span>`,
+  `<span style="color:#818cf8">╌ Drop&nbsp;&nbsp;&nbsp;${p.drop_pct!=null?p.drop_pct.toFixed(1)+'%':'—'}</span>`,
+  p.reach_pct!=null?`<span style="color:#22c55e">✔ Allow&nbsp;&nbsp;${p.reach_pct.toFixed(1)+'%'}</span>`:''
+]);
 checkRole();
 connect();
 setInterval(checkRole,5000);


### PR DESCRIPTION
## Summary
- Wire the existing `wireTip()` hover infrastructure to the `sec-trend` canvas
- Tooltip shows timestamp, Block%, Drop%, and Allow% at the cursor position — same UX as the Overview sparkline

## Test plan
- [ ] Security page: hover over Block &amp; Drop Trend chart
- [ ] Tooltip appears showing timestamp, block %, drop %, and allow % values
- [ ] Tooltip follows cursor and disappears on mouse leave

---
_Generated by [Claude Code](https://claude.ai/code/session_01QiHkJ7DeFEB7bsfFW93bXW)_