### PR TITLE
Live View auto-scroll self-healing

### DIFF
--- a/webui.py
+++ b/webui.py
@@ -1456,7 +1456,7 @@ function _hideWaitBanner(){
   const wb=$('wait-banner');if(wb)wb.style.display='none';
   _waitBannerUntil=0;
 }
-(()=>{const ob=$('obody');if(!ob)return;ob.addEventListener('scroll',()=>{if(_scrollLock)return;const atBot=ob.scrollHeight-ob.scrollTop-ob.clientHeight<80;if(atBot&&!_autoScroll){_autoScroll=true;const b=$('btn-as');if(b)b.innerHTML='Auto-scroll &#10003;';}else if(!atBot&&_autoScroll){_autoScroll=false;const b=$('btn-as');if(b)b.innerHTML='Auto-scroll &#10007;';}},{passive:true});})();
+(()=>{const ob=$('obody');if(!ob)return;ob.addEventListener('scroll',()=>{if(_scrollLock)return;const gap=ob.scrollHeight-ob.scrollTop-ob.clientHeight;const atBot=gap<120;if(atBot&&!_autoScroll){_autoScroll=true;const b=$('btn-as');if(b)b.innerHTML='Auto-scroll &#10003;';}else if(!atBot&&_autoScroll){_autoScroll=false;const b=$('btn-as');if(b)b.innerHTML='Auto-scroll &#10007;';}},{passive:true});})();
 let _lastState=null,_logEs=null,_logFilter='all';
 let _xRows=new Set(),_xEvs=new Set(),_modalSuite=null,_isPaused=false,_lastTest=null;
 let _SD={};  // suite name → description, populated on first state arrival
@@ -1713,10 +1713,23 @@ function appendLog(d){
   }
   if(!structural&&_logFilter!=='all'&&!div.classList.contains(_logFilter))div.style.display='none';
   b.appendChild(div);
-  if(_autoScroll)requestAnimationFrame(()=>{const ob=$('obody');if(ob){_scrollLock=true;ob.scrollTop=ob.scrollHeight;requestAnimationFrame(()=>{_scrollLock=false;});}});
+  if(_autoScroll)_scrollToBot();
   while(b.children.length>800)b.removeChild(b.firstChild);
 }
-function toggleAS(){_autoScroll=!_autoScroll;$('btn-as').innerHTML='Auto-scroll '+(_autoScroll?'&#10003;':'&#10007;');}
+function _scrollToBot(){
+  const ob=$('obody');if(!ob)return;
+  _scrollLock=true;
+  ob.scrollTop=ob.scrollHeight;
+  setTimeout(()=>{_scrollLock=false;},50);
+}
+// Self-healing: if auto-scroll is on but we drifted from the bottom, catch up
+setInterval(()=>{
+  if(!_autoScroll)return;
+  const ob=$('obody');if(!ob)return;
+  const gap=ob.scrollHeight-ob.scrollTop-ob.clientHeight;
+  if(gap>120)_scrollToBot();
+},2000);
+function toggleAS(){_autoScroll=!_autoScroll;$('btn-as').innerHTML='Auto-scroll '+(_autoScroll?'&#10003;':'&#10007;');if(_autoScroll)_scrollToBot();}
 
 // ── Draggable overview widgets ─────────────────────────────────────────────────
 function _initDrag(gridId){


### PR DESCRIPTION
## Summary
- Extract `_scrollToBot()` — uses `setTimeout(50ms)` to release `_scrollLock` instead of a nested `requestAnimationFrame`, eliminating the race condition where the browser scroll event fired before the lock released
- Add a 2-second interval self-healer: if auto-scroll is enabled but the scroll position has drifted more than 120px from the bottom, force a scroll to the bottom
- Widen "at bottom" threshold 80px → 120px so minor rendering-lag doesn't falsely disable auto-scroll
- `toggleAS()` immediately scrolls to bottom when re-enabling

## Test plan
- [ ] Live View streams many lines — auto-scroll keeps up
- [ ] Manually scrolling up disables auto-scroll (button shows ✗)
- [ ] Scrolling back to bottom re-enables auto-scroll (button shows ✓)
- [ ] If scroll somehow stalls, the 2s healer catches up within the next cycle

---
_Generated by [Claude Code](https://claude.ai/code/session_01QiHkJ7DeFEB7bsfFW93bXW)_