### PR TITLE
fix: use -p 7777:7777 in Quick Start instead of --network=host

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ This tool is intended for **authorized security testing and research in controll
 ```bash
 # Run all suites in a continuous loop
 docker run --pull=always --detach --restart unless-stopped \
-  --network=host --name traffgen jdibby/traffgen:latest \
+  -p 7777:7777 --name traffgen jdibby/traffgen:latest \
   --suite=all --size=S --max-wait-secs=20 --loop
 
 # Then open the dashboard


### PR DESCRIPTION
Quick Start was using `--network=host` which hides how port 7777 is exposed — readers couldn't tell where the dashboard URL came from. Replaced with `-p 7777:7777` so the port mapping is explicit and the connection between the `docker run` command and `https://<host-ip>:7777` is obvious.

`--network=host` is still documented in `docs/deployment.md` for cases where lateral movement LAN scanning is needed.

https://claude.ai/code/session_01QiHkJ7DeFEB7bsfFW93bXW

---
_Generated by [Claude Code](https://claude.ai/code/session_01QiHkJ7DeFEB7bsfFW93bXW)_