### PR TITLE
fix: tls-check false-clean when Cato uses hyphenated CA CN

### DIFF
--- a/generator.py
+++ b/generator.py
@@ -3140,6 +3140,7 @@ def tls_inspection_check() -> None:
         ("fortigate",        "Fortinet (FortiGate)"),
         ("fortinet",         "Fortinet"),
         ("cato networks",    "Cato Networks"),
+        ("cato-networks",    "Cato Networks"),
         ("cato ",            "Cato Networks"),
         ("cisco umbrella",   "Cisco Umbrella"),
         ("cisco",            "Cisco"),
@@ -3171,9 +3172,12 @@ def tls_inspection_check() -> None:
     ]
 
     def _detect_vendor(issuer_cn: str, issuer_org: str) -> str:
-        combined = (issuer_cn + " " + issuer_org).lower()
+        # Normalise hyphens → spaces so "Cato-Networks-Server-xyz" matches
+        # the token "cato networks", and similarly for other hyphenated CAs.
+        raw = (issuer_cn + " " + issuer_org).lower()
+        combined = raw.replace("-", " ")
         for token, display in _PROXY_VENDOR_MAP:
-            if token in combined:
+            if token in combined or token in raw:
                 return display
         return ""
 


### PR DESCRIPTION
Fixes `tls-check` reporting CLEAN when Cato Networks is actively intercepting TLS.

**Root cause:** Cato certificates use `Cato-Networks-Server-<location>` as the CN — hyphens, not spaces. `_detect_vendor()` built `combined` from the raw lowercase string, so the tokens `"cato networks"` (space) and `"cato "` (trailing space) both failed to find a match in `"cato-networks-server-dencatod7"`. The result was CLEAN + "✔ No TLS inspection detected" even with Cato clearly intercepting multiple sites.

**Fix:**
- Normalize hyphens → spaces in `combined` before matching, so `"cato-networks-server-dencatod7"` becomes `"cato networks server dencatod7"` and matches `"cato networks"`
- Also match against the original raw string as a fallback
- Add `"cato-networks"` as an explicit token for belt-and-suspenders coverage

This also future-proofs detection against other vendors that might use hyphens in their CA CN.

https://claude.ai/code/session_01QiHkJ7DeFEB7bsfFW93bXW

---
_Generated by [Claude Code](https://claude.ai/code/session_01QiHkJ7DeFEB7bsfFW93bXW)_