### PR TITLE
feat(lateral-movement): per-run network selector in WebUI and CLI

### DIFF
--- a/generator.py
+++ b/generator.py
@@ -667,6 +667,14 @@ def _argv_from_cmd(cmd: dict) -> list:
         argv.append("--loop")
     if cmd.get("nowait", False):
         argv.append("--nowait")
+    # Preserve lateral-movement network filter if provided
+    lat_nets = cmd.get("lateral_networks", [])
+    if isinstance(lat_nets, list):
+        lat_nets = [n for n in lat_nets if isinstance(n, str) and "/" in n]
+    else:
+        lat_nets = []
+    if lat_nets:
+        argv.append(f"--lateral-networks={','.join(lat_nets)}")
     return argv
 
 
@@ -3933,11 +3941,22 @@ def lateral_movement_sim() -> None:
     _LATERAL_PORTS = "22,88,135,137,138,139,389,445,636,3389,5985,5986"
 
     # ── Detect all physical host LANs ─────────────────────────────────────────
-    lans = _detect_host_lans()
-    if not lans:
+    all_lans = _detect_host_lans()
+    if not all_lans:
         ui_warn("lateral_movement_sim: cannot determine host LAN subnet — skipping")
         _stats.fail()
         return
+
+    # Apply network filter from --lateral-networks CLI arg (or web settings)
+    _lat_filter = [n.strip() for n in getattr(ARGS, "lateral_networks", "").split(",") if n.strip()]
+    if _lat_filter:
+        lans = [(ip, cidr) for ip, cidr in all_lans if cidr in _lat_filter]
+        if not lans:
+            ui_warn(f"lateral_movement_sim: none of the specified networks {_lat_filter} "
+                    f"were detected — falling back to all networks")
+            lans = all_lans
+    else:
+        lans = all_lans
 
     _cidr_env = os.environ.get("HOST_LAN_CIDR", "").strip()
     _src = "stager.sh" if _cidr_env else "auto-detected"
@@ -4438,6 +4457,13 @@ def parse_cli() -> argparse.Namespace:
         metavar="URL",
         help="Seed URL for the 'crawl' suite (default: https://data.commoncrawl.org)",
     )
+    specific.add_argument(
+        "--lateral-networks", default="", metavar="CIDRS",
+        help=(
+            "Comma-separated list of CIDRs to target in the 'lateral-movement' suite\n"
+            "(e.g. 192.168.1.0/24,10.0.0.0/24). Omit to scan all detected networks."
+        ),
+    )
 
     args = parser.parse_args()
 
@@ -4514,6 +4540,8 @@ if __name__ == "__main__":
         ARGS      = parse_cli()
 
         # Initialise web UI state from CLI arguments
+        _detected_lans = _detect_host_lans()
+        _lat_filter = [n.strip() for n in getattr(ARGS, "lateral_networks", "").split(",") if n.strip()]
         with _WEB_STATE_LOCK:
             _WEB_STATE.update({
                 "version":       VERSION,
@@ -4524,6 +4552,10 @@ if __name__ == "__main__":
                 "loop":          getattr(ARGS, "loop", False),
                 "suites":        [{"name": n, "description": d}
                                   for n, d in _SUITE_DESCRIPTIONS],
+                "lateral_networks_available": [
+                    {"ip": ip, "cidr": cidr} for ip, cidr in _detected_lans
+                ],
+                "lateral_networks": _lat_filter,
             })
         _web_flush()
         _web_log(

--- a/webui.py
+++ b/webui.py
@@ -660,12 +660,20 @@ def api_control():
     except (TypeError, ValueError):
         return jsonify({"error": "max_wait_secs must be an integer 5-300"}), 400
 
+    # lateral_networks: list of CIDRs to filter lateral-movement targets
+    lat_raw = d.get("lateral_networks", [])
+    if isinstance(lat_raw, list):
+        lat_nets = [str(n) for n in lat_raw if isinstance(n, str) and "/" in n]
+    else:
+        lat_nets = []
+
     cmd = {
-        "suite":         suite,
-        "size":          size,
-        "max_wait_secs": wait,
-        "loop":          bool(d.get("loop", True)),
-        "nowait":        bool(d.get("nowait", False)),
+        "suite":            suite,
+        "size":             size,
+        "max_wait_secs":    wait,
+        "loop":             bool(d.get("loop", True)),
+        "nowait":           bool(d.get("nowait", False)),
+        "lateral_networks": lat_nets,
     }
     try:
         tmp = _CMD_FILE + ".tmp"
@@ -676,6 +684,16 @@ def api_control():
         return jsonify({"error": str(e)}), 500
 
     return jsonify({"ok": True, "applied": cmd})
+
+
+@app.route("/api/networks")
+def api_networks():
+    """Return available lateral-movement networks detected by the generator."""
+    st = _read_state()
+    return jsonify({
+        "available": st.get("lateral_networks_available", []),
+        "selected":  st.get("lateral_networks", []),
+    })
 
 
 @app.route("/events")
@@ -1533,7 +1551,14 @@ docker run --pull=always -it jdibby/traffgen:latest --suite=dns --size=L</div>
   <div class="dbody">
     <div style="font-size:12px;color:var(--muted)">Current configuration:</div>
     <div class="cur-cfg" id="cur-cfg">&#8212;</div>
-    <div class="field"><label>Suite</label><select id="cfg-suite"><option value="all">all &#8212; run everything</option></select></div>
+    <div class="field"><label>Suite</label><select id="cfg-suite" onchange="onSuiteChange(this.value)"><option value="all">all &#8212; run everything</option></select></div>
+    <div id="lateral-nets-section" style="display:none">
+      <div class="field" style="flex-direction:column;align-items:flex-start;gap:6px">
+        <label style="margin-bottom:2px">Networks to scan <span style="font-weight:400;color:var(--muted)">(none = all)</span></label>
+        <div id="lateral-nets-list" style="display:flex;flex-direction:column;gap:5px;width:100%"></div>
+        <div id="lateral-nets-none" style="font-size:12px;color:var(--muted);display:none">No networks detected — will auto-detect at runtime</div>
+      </div>
+    </div>
     <div class="field"><label>Size</label>
       <select id="cfg-size">
         <option value="XS">XS &#8212; Extra Small (minimal)</option>
@@ -1946,12 +1971,51 @@ function _restoreWidgetOrder(gridId){
   if(!order||!order.length)return;
   order.forEach(id=>{const c=grid.querySelector('[data-widget="'+id+'"]');if(c)grid.appendChild(c);});
 }
-function openDrawer(){$('drawer').classList.add('open');$('overlay').classList.add('open');}
+let _lateralNetsAvailable=[];
+function onSuiteChange(val){
+  const sec=$('lateral-nets-section');
+  if(val==='lateral-movement'){
+    sec.style.display='';
+    fetch('/api/networks').then(r=>r.json()).then(d=>{
+      _lateralNetsAvailable=d.available||[];
+      const selected=new Set(d.selected||[]);
+      const list=$('lateral-nets-list');
+      const none=$('lateral-nets-none');
+      list.innerHTML='';
+      if(!_lateralNetsAvailable.length){none.style.display='';return;}
+      none.style.display='none';
+      _lateralNetsAvailable.forEach(net=>{
+        const lbl=document.createElement('label');
+        lbl.style.cssText='display:flex;align-items:center;gap:8px;font-size:13px;cursor:pointer;padding:5px 8px;border-radius:6px;background:var(--surf2);border:1px solid var(--border)';
+        const cb=document.createElement('input');
+        cb.type='checkbox';cb.value=net.cidr;cb.checked=selected.size===0||selected.has(net.cidr);
+        const txt=document.createElement('span');
+        txt.innerHTML=`<span style="font-family:monospace;font-weight:600">${H(net.cidr)}</span><span style="color:var(--muted);font-size:11px;margin-left:4px">(${H(net.ip)})</span>`;
+        lbl.appendChild(cb);lbl.appendChild(txt);list.appendChild(lbl);
+      });
+    }).catch(()=>{});
+  }else{
+    sec.style.display='none';
+  }
+}
+function openDrawer(){
+  $('drawer').classList.add('open');$('overlay').classList.add('open');
+  // Trigger lateral nets section if current suite is lateral-movement
+  onSuiteChange($('cfg-suite').value);
+}
 function closeDrawer(){$('drawer').classList.remove('open');$('overlay').classList.remove('open');}
 function toast(msg,ok){const t=$('toast');t.textContent=msg;t.className='toast '+(ok?'ok':'err');t.style.display='block';setTimeout(()=>t.style.display='none',3500);}
 function applySettings(){
   if(!_isAdmin){toast(_sessionMode?'Another session has control — you are read-only':'Admin access required — click Unlock',false);return;}
-  const body={suite:$('cfg-suite').value,size:$('cfg-size').value,max_wait_secs:parseInt($('cfg-wait').value),loop:$('cfg-loop').checked,nowait:$('cfg-nowait').checked};
+  const suite=$('cfg-suite').value;
+  const body={suite,size:$('cfg-size').value,max_wait_secs:parseInt($('cfg-wait').value),loop:$('cfg-loop').checked,nowait:$('cfg-nowait').checked};
+  if(suite==='lateral-movement'&&_lateralNetsAvailable.length){
+    const checked=[...document.querySelectorAll('#lateral-nets-list input[type=checkbox]:checked')].map(c=>c.value);
+    // If all checked (or none explicitly unchecked), send empty = scan all
+    body.lateral_networks=(checked.length===_lateralNetsAvailable.length)?[]:checked;
+  }else{
+    body.lateral_networks=[];
+  }
   _ctrl(body).then(r=>r.json()).then(d=>{if(d.ok){toast('Settings applied — restarting at next boundary…',true);closeDrawer();}else toast('Error: '+d.error,false);})
     .catch(()=>toast('Request failed',false));
 }


### PR DESCRIPTION
## Summary

- **WebUI**: When the Settings drawer is opened with `lateral-movement` selected as the suite, a network checklist appears showing all detected interfaces/subnets. Uncheck any to exclude them from the scan. If all are checked (the default), sends an empty filter = scan everything.
- **CLI**: New `--lateral-networks` flag accepts a comma-separated list of CIDRs (e.g. `--lateral-networks=192.168.1.0/24,10.0.0.0/24`). Omit the flag to scan all detected networks.
- **API**: New `GET /api/networks` endpoint returns `{available: [...], selected: [...]}` from the generator's state — the UI fetches this when opening the network selector.
- **Persistence**: Selected networks survive generator restarts — `_argv_from_cmd()` converts the list back to `--lateral-networks=x,y,z` for `execv`.

## Test plan

- [ ] Open Settings drawer, select `lateral-movement` suite — network checklist appears with all detected networks pre-checked
- [ ] Uncheck one network, apply — generator restarts and only scans the checked subnets
- [ ] Check all networks (or leave all checked), apply — empty filter sent, all networks scanned
- [ ] No networks detected edge case: "No networks detected — will auto-detect at runtime" message shown
- [ ] CLI: `--lateral-networks=192.168.1.0/24` restricts to that subnet; invalid/undetected CIDR falls back to all with a warning
- [ ] `GET /api/networks` returns available networks and current selection

https://claude.ai/code/session_01QiHkJ7DeFEB7bsfFW93bXW

---
_Generated by [Claude Code](https://claude.ai/code/session_01QiHkJ7DeFEB7bsfFW93bXW)_