### PR TITLE
fix(webui): add missing icons for msf-aux-scan, msf-payload-delivery, msf-cred-spray

### DIFF
--- a/webui.py
+++ b/webui.py
@@ -1766,6 +1766,7 @@ const SUITE_ICONS={
   'c2-useragents':'👾','malware-samples':'🦠','av-test':'☣️',
   'msf-webapp':'🌐','msf-enterprise':'🏢','msf-appliance':'📡',
   'msf-cisa-kev':'🚨','msf-middleware':'⚙️','msf-recon':'🔭',
+  'msf-aux-scan':'🔍','msf-payload-delivery':'📦','msf-cred-spray':'🔑',
   'speedtest':'🚀','nmap':'🗺️','ntp':'🕐','phishing-domains':'🎣',
   'pornography':'🔞','snmp':'📊','squatting':'🔤','s3':'🪣',
   'ssh':'💻','url-latency':'⏱️','web-scanner':'🔬',


### PR DESCRIPTION
All 52 suites now have entries in `SUITE_ICONS`. The three older MSF suites added in v3.3.0 were missed when the new themed suites got their icons in v3.4.0.

https://claude.ai/code/session_01QiHkJ7DeFEB7bsfFW93bXW

---
_Generated by [Claude Code](https://claude.ai/code/session_01QiHkJ7DeFEB7bsfFW93bXW)_