### PR TITLE
fix(webui): disk I/O bars always-full at low activity

### DIFF
--- a/webui.py
+++ b/webui.py
@@ -2356,7 +2356,8 @@ function drawDiskBars(r,w){
   c.width=Math.floor(rect.width)||300;c.height=58;
   const ctx=c.getContext('2d'),W=c.width,bh=16,lw=48,gy=6;
   ctx.clearRect(0,0,W,58);
-  const mx=Math.max(r,w,1);
+  _diskPeakHist.push(Math.max(r,w));if(_diskPeakHist.length>60)_diskPeakHist.shift();
+  const mx=Math.max(..._diskPeakHist,500);
   const drawBar=(y,v,col,lbl)=>{
     ctx.fillStyle=_canvasMuted();ctx.font='12px SF Mono,Consolas,monospace';ctx.textAlign='right';ctx.textBaseline='middle';ctx.fillText(lbl,lw-4,y+bh/2);
     ctx.fillStyle=_canvasBg();ctx.fillRect(lw,y,W-lw-gy,bh);
@@ -2479,6 +2480,7 @@ pollNetInfo();
 setInterval(pollNetInfo,30000);
 // ── Security Summary ──────────────────────────────────────────────────────────
 let _secTimer=null,_secInterval=1000,_secHist=[];
+let _diskPeakHist=[];
 function drawSecDonut(allowed,blocked,dropped,other){
   const c=$('sec-donut');if(!c)return;
   const ctx=c.getContext('2d'),W=c.width,H2=c.height,cx=W/2,cy=H2/2,r=66,ri=46;


### PR DESCRIPTION
## Problem

The Disk I/O Write bar was always shown at 100% even at 0.02 Mbps. The scale was `Math.max(r, w, 1)` — whichever value was larger became the ceiling, so 0.02 Mbps write vs <0.01 Mbps read meant write = 100% of the bar.

## Fix

Added a 60-reading rolling peak history (`_diskPeakHist`) with a 500 kB/s floor (~4 Mbps display). The bar now scales to the recent sustained peak:
- Light activity (0.02 Mbps) → tiny sliver
- Moderate activity → proportional bar
- Heavy activity → bar fills as expected
- After a burst subsides, the scale shrinks back over ~2.5 minutes

https://claude.ai/code/session_01QiHkJ7DeFEB7bsfFW93bXW

---
_Generated by [Claude Code](https://claude.ai/code/session_01QiHkJ7DeFEB7bsfFW93bXW)_