### PR TITLE
feat(security): per-row block rate trend sparklines in breakdown table

### DIFF
--- a/webui.py
+++ b/webui.py
@@ -2622,6 +2622,7 @@ pollNetInfo();
 setInterval(pollNetInfo,30000);
 // ── Security Summary ──────────────────────────────────────────────────────────
 let _secTimer=null,_secInterval=1000,_secHist=[];
+const _suiteHist={};
 let _diskPeakHist=[];
 function drawSecDonut(allowed,blocked,dropped,other){
   const c=$('sec-donut');if(!c)return;
@@ -2678,13 +2679,31 @@ function updateSecurityTab(){
   // per-suite table — sort by blocked desc
   const rows=Object.entries(tests).map(([n,t])=>({n,ta:t.attempts||0,rch:t.allowed||0,blk:t.blocked||0,drp:t.dropped||0,tot:(t.allowed||0)+(t.blocked||0)+(t.dropped||0)}));
   rows.sort((a,b)=>b.blk-a.blk||(b.drp-a.drp));
+  // record per-suite block rate history
+  rows.forEach(r=>{
+    if(!_suiteHist[r.n])_suiteHist[r.n]=[];
+    const bp=r.tot?r.blk/r.tot*100:0;
+    _suiteHist[r.n].push(bp);
+    if(_suiteHist[r.n].length>20)_suiteHist[r.n].shift();
+  });
   const tb=$('sec-tbl');
-  if(!rows.length){tb.innerHTML='<tr><td colspan="7" class="empty">Waiting…</td></tr>';}
+  if(!rows.length){tb.innerHTML='<tr><td colspan="8" class="empty">Waiting…</td></tr>';}
   else tb.innerHTML=rows.map(r=>{
     const bp=r.tot?r.blk/r.tot*100:0,dp=r.tot?r.drp/r.tot*100:0;
     const bpC=bp>50?'var(--red)':bp>10?'var(--amber)':'var(--muted)';
     const dpC=dp>50?'var(--red)':dp>10?'#818cf8':'var(--muted)';
-    return`<tr class="mrow"><td class="nm" title="${_SD[r.n]||''}" style="cursor:default"><span class="s-ico">${suiteIco(r.n)}</span>${H(r.n)}</td><td class="r">${N(r.tot)}</td><td class="r" style="color:#22c55e">${N(r.rch)}</td><td class="r" style="color:var(--amber)">${N(r.blk)}</td><td class="r" style="color:#818cf8">${N(r.drp)}</td><td class="r"><span style="color:${bpC}">${r.tot?bp.toFixed(1)+'%':'—'}</span></td><td class="r"><span style="color:${dpC}">${r.tot?dp.toFixed(1)+'%':'—'}</span></td></tr>`;
+    const hist=_suiteHist[r.n]||[];
+    let trendSvg='<span style="color:var(--dim);font-size:11px">—</span>';
+    if(hist.length>=3){
+      const pts=hist.slice(-10),mx=Math.max(...pts,1),mn=Math.min(...pts);
+      const last=pts[pts.length-1],first=pts[0];
+      const trendC=last>first+1?'var(--red)':last<first-1?'#22c55e':'var(--dim)';
+      const w=60,h=16,pad=1;
+      const px=(i)=>pad+i*(w-2*pad)/(pts.length-1||1);
+      const py=(v)=>h-pad-(mx===mn?h/2:(v-mn)/(mx-mn)*(h-2*pad));
+      trendSvg=`<svg width="60" height="16" style="vertical-align:middle" title="${hist.map(v=>v.toFixed(1)+'%').join(', ')}"><polyline fill="none" stroke="${trendC}" stroke-width="1.5" points="${pts.map((v,i)=>px(i).toFixed(1)+','+py(v).toFixed(1)).join(' ')}" /></svg>`;
+    }
+    return`<tr class="mrow"><td class="nm" title="${_SD[r.n]||''}" style="cursor:default"><span class="s-ico">${suiteIco(r.n)}</span>${H(r.n)}</td><td class="r">${N(r.tot)}</td><td class="r" style="color:#22c55e">${N(r.rch)}</td><td class="r" style="color:var(--amber)">${N(r.blk)}</td><td class="r" style="color:#818cf8">${N(r.drp)}</td><td class="r"><span style="color:${bpC}">${r.tot?bp.toFixed(1)+'%':'—'}</span></td><td class="r"><span style="color:${dpC}">${r.tot?dp.toFixed(1)+'%':'—'}</span></td><td class="r">${trendSvg}</td></tr>`;
   }).join('');
   // block signal breakdown — aggregate codes across filtered tests
   const codeTotals={};


### PR DESCRIPTION
## Summary
- New Trend column added to the Per-Suite Security Breakdown table
- Each row shows a 60×16px SVG sparkline of its last 10 block-rate readings
- Green when rate is declining, red when rising, gray when flat
- Dash shown until at least 3 data points are collected

Closes #224

https://claude.ai/code/session_01QiHkJ7DeFEB7bsfFW93bXW

---
_Generated by [Claude Code](https://claude.ai/code/session_01QiHkJ7DeFEB7bsfFW93bXW)_