### PR TITLE
fix(js): replace fragile window.apply/showTab monkey-patches

### DIFF
--- a/webui.py
+++ b/webui.py
@@ -3083,8 +3083,7 @@ document.addEventListener('DOMContentLoaded',_renderRunHistory);
         +'</div>';
     }).join('');
   }
-  const _origApply=apply;
-  window.apply=function(s){_origApply(s);_render(s);};
+  setInterval(function(){if(_lastState)_render(_lastState);},1000);
 })();
 function exportResults(fmt){
   if(!_lastState){toast('No data to export yet',false);return;}
@@ -3105,8 +3104,10 @@ function exportResults(fmt){
 }
 (function(){
   const _VALID_TABS=new Set(['overview','security','tests','output','diagnostics','health','about','changelog']);
-  const _origShowTab=showTab;
-  window.showTab=function(btn){_origShowTab(btn);const t=btn&&btn.dataset&&btn.dataset.tab;if(t)history.replaceState(null,'','#'+t);};
+  document.addEventListener('click',function(e){
+    const btn=e.target.closest('.nav-item[data-tab]');
+    if(btn&&_VALID_TABS.has(btn.dataset.tab))history.replaceState(null,'','#'+btn.dataset.tab);
+  },true);
   function _navHash(){const t=(location.hash||'').replace('#','');if(_VALID_TABS.has(t))navTo(t);}
   window.addEventListener('hashchange',_navHash);
   document.addEventListener('DOMContentLoaded',_navHash);


### PR DESCRIPTION
## Problem

`window.X = newFn` does not reliably override a global `function X()` declaration for direct identifier lookups. JavaScript resolves function declarations through the global declarative environment record, which takes precedence over the window object record. This means the original `apply()` and `showTab()` were still being called by the rest of the script, breaking the monkey-chain and potentially causing runtime errors if the patched versions had side-effects that conflicted.

## Fix

- **Top Failing Suites widget**: replace `window.apply = patchedFn` with `setInterval(() => { if(_lastState) _render(_lastState); }, 1000)` — polls `_lastState` directly, no global patching
- **URL fragment routing**: replace `window.showTab = patchedFn` with a capture-phase `document.addEventListener('click', ...)` on `.nav-item[data-tab]` elements — updates the hash on nav clicks without touching any global function binding

## Test plan

- [ ] Clicking nav tabs works correctly (tabs switch, no JS errors)
- [ ] URL hash updates in the address bar when switching tabs
- [ ] Loading `#health` in the URL navigates to the Health tab on load
- [ ] Top Failing Suites widget updates (within ~1s of state change)
- [ ] All other existing features still work

https://claude.ai/code/session_01QiHkJ7DeFEB7bsfFW93bXW

---
_Generated by [Claude Code](https://claude.ai/code/session_01QiHkJ7DeFEB7bsfFW93bXW)_