### PR TITLE
fix(js): fix SyntaxError from \\n escape in JS strings inside Python _HTML

### DIFF
--- a/webui.py
+++ b/webui.py
@@ -3095,8 +3095,8 @@ function exportResults(fmt){
     const payload={exported_at:new Date().toISOString(),status:_lastState.status||'',totals:tot,suites:rows};
     content=JSON.stringify(payload,null,2);mime='application/json';ext='json';
   } else {
-    const hdr='suite,attempts,ok,fail,allowed,blocked,dropped\n';
-    content=hdr+rows.map(r=>[r.suite,r.attempts,r.ok,r.fail,r.allowed,r.blocked,r.dropped].join(',')).join('\n');
+    const hdr='suite,attempts,ok,fail,allowed,blocked,dropped\\n';
+    content=hdr+rows.map(r=>[r.suite,r.attempts,r.ok,r.fail,r.allowed,r.blocked,r.dropped].join(',')).join('\\n');
     mime='text/csv';ext='csv';
   }
   const a=document.createElement('a');a.href=URL.createObjectURL(new Blob([content],{type:mime}));

--- a/webui.py
+++ b/webui.py
@@ -3058,10 +3058,11 @@ document.addEventListener('DOMContentLoaded',_renderRunHistory);
     if(k==='Escape'){if($('drawer').classList.contains('open')){closeDrawer();}const m=$('suite-modal');if(m&&m.style.display!=='none'){closeModal&&closeModal();}return;}
     if(k==='?'){showKbHelp();return;}
   });
-  const _KBH_HTML='<div id="kb-overlay" onclick="if(event.target.id===\'kb-overlay\')this.remove()" style="position:fixed;inset:0;background:rgba(0,0,0,.6);z-index:10000;display:flex;align-items:center;justify-content:center"><div style="background:#1a1f2e;border:1px solid rgba(255,255,255,.12);border-radius:14px;padding:24px 32px;min-width:340px;max-width:480px"><div style="font-weight:700;font-size:16px;color:#e8eaf0;margin-bottom:16px">Keyboard Shortcuts</div><table style="width:100%;border-collapse:collapse;font-size:14px">'+
+  window._closeKbHelp=function(){const o=document.getElementById('kb-overlay');if(o)o.remove();};
+  const _KBH_HTML='<div id="kb-overlay" onclick="if(event.target===this)_closeKbHelp()" style="position:fixed;inset:0;background:rgba(0,0,0,.6);z-index:10000;display:flex;align-items:center;justify-content:center"><div style="background:#1a1f2e;border:1px solid rgba(255,255,255,.12);border-radius:14px;padding:24px 32px;min-width:340px;max-width:480px"><div style="font-weight:700;font-size:16px;color:#e8eaf0;margin-bottom:16px">Keyboard Shortcuts</div><table style="width:100%;border-collapse:collapse;font-size:14px">'+
     [['1–7','Navigate tabs'],['R','Restart tests'],['P','Pause / Resume'],['Esc','Close modal / drawer'],['?','This help']]
     .map(([k,v])=>'<tr><td style="padding:5px 16px 5px 0;font-family:SF Mono,Consolas,monospace;color:#22c55e;white-space:nowrap">'+k+'</td><td style="padding:5px 0;color:#9aa3b8">'+v+'</td></tr>').join('')+
-    '</table><button onclick="document.getElementById(\'kb-overlay\').remove()" style="margin-top:16px;padding:6px 18px;background:rgba(255,255,255,.08);border:1px solid rgba(255,255,255,.12);border-radius:8px;color:#e8eaf0;cursor:pointer;font-size:13px">Close</button></div></div>';
+    '</table><button onclick="_closeKbHelp()" style="margin-top:16px;padding:6px 18px;background:rgba(255,255,255,.08);border:1px solid rgba(255,255,255,.12);border-radius:8px;color:#e8eaf0;cursor:pointer;font-size:13px">Close</button></div></div>';
   window.showKbHelp=function(){if(!$('kb-overlay')){document.body.insertAdjacentHTML('beforeend',_KBH_HTML);}};
 })();
 (function(){


### PR DESCRIPTION
## Problem

Python interprets `\n` inside a triple-quoted string as a **real newline character** (not the two-character escape sequence). The `exportResults` CSV code used `'\n'` in JS single-quoted string literals:

```python
# Python source (inside _HTML = """..."""):
const hdr='suite,attempts,ok,fail,allowed,blocked,dropped\n';    # \n → real newline in output!
content=...join(',')).join('\n');                                  # \n → real newline in output!
```

The served HTML contained a raw newline inside a JS single-quoted string — an `Invalid or unexpected token` SyntaxError that halted all subsequent JS execution (same "can't click anything" symptom as before).

## Fix

Use `\\n` in the Python source so Python outputs the two-character JS escape sequence `\n`:

```python
const hdr='suite,attempts,ok,fail,allowed,blocked,dropped\\n';
content=...join(',')).join('\\n');
```

## Test plan

- [ ] Page loads with no console errors
- [ ] Nav tabs are clickable
- [ ] CSV export downloads a file with newline-separated rows
- [ ] JSON export still works

https://claude.ai/code/session_01QiHkJ7DeFEB7bsfFW93bXW

---
_Generated by [Claude Code](https://claude.ai/code/session_01QiHkJ7DeFEB7bsfFW93bXW)_