### PR TITLE
fix: Suite Latency widget autosizes to show all rows

### DIFF
--- a/webui.py
+++ b/webui.py
@@ -1808,7 +1808,7 @@ body.ro-mode .ro-ctrl{opacity:.32;cursor:not-allowed}
           <canvas id="lat-heatmap"></canvas>
         </div>
       </div>
-      <div class="tcard" data-widget="lat-table">
+      <div class="tcard" data-widget="lat-table" style="flex-shrink:0">
         <div class="thdr">Suite Latency <span style="color:var(--dim);font-weight:400;letter-spacing:0;text-transform:none;font-size:12px">P50 · P95 · P99 from observed avg_dur_ms samples</span></div>
         <table><thead><tr><th>Suite</th><th class="r">Samples</th><th class="r">Min</th><th class="r">P50</th><th class="r">P95</th><th class="r">P99</th><th class="r">Max</th></tr></thead>
         <tbody id="lat-tbody"><tr><td colspan="7" class="empty">Waiting for data&#8230; Run at least one test to begin tracking.</td></tr></tbody></table>


### PR DESCRIPTION
## Summary

The Suite Latency tcard was a flex child with default `flex-shrink:1`. With 50+ test suites the card was compressed by the flex algorithm and rows were clipped by `overflow:hidden`. Adding `flex-shrink:0` lets the card grow to its natural height so all rows are visible; the panel's `overflow-y:auto` handles scrolling.

https://claude.ai/code/session_01QiHkJ7DeFEB7bsfFW93bXW

---
_Generated by [Claude Code](https://claude.ai/code/session_01QiHkJ7DeFEB7bsfFW93bXW)_