### PR TITLE
fix: resolve deadlock that froze all dashboard widgets (regression from v3.4.0)

### DIFF
--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -31,9 +31,9 @@ jobs:
         run: |
           ver=$(python3 -c "
           import re, sys
-          m = re.search(r'VERSION\s*=\s*[\"\']([\d.]+)[\"\']]', open('generator.py').read())
+          m = re.search(r'VERSION\s*=\s*[\"\'](\ d[\ d.]+)[\"\']', open('generator.py').read())
           if not m:
-              m = re.search(r'[\"\']([\d]+\.\d+\.\d+)[\"\']]', open('generator.py').read())
+              m = re.search(r'[\"\'](\ d+\.\ d+\.\ d+)[\"\']', open('generator.py').read())
           if m:
               print(m.group(1))
           else:

--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -29,16 +29,10 @@ jobs:
       - name: Extract VERSION from generator.py
         id: version
         run: |
-          ver=$(python3 -c "
-          import re, sys
-          m = re.search(r'VERSION\s*=\s*[\"\'](\ d[\ d.]+)[\"\']', open('generator.py').read())
-          if not m:
-              m = re.search(r'[\"\'](\ d+\.\ d+\.\ d+)[\"\']', open('generator.py').read())
-          if m:
-              print(m.group(1))
-          else:
-              print('NOT_FOUND')
-          " 2>/dev/null || echo "NOT_FOUND")
+          ver=$(grep -oE '^VERSION = "[0-9]+\.[0-9]+\.[0-9]+"' generator.py \
+                | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' \
+                | head -1 || echo "NOT_FOUND")
+          [ -z "$ver" ] && ver="NOT_FOUND"
           echo "version=$ver" >> "$GITHUB_OUTPUT"
           echo "Detected version: $ver"
 
@@ -64,7 +58,7 @@ jobs:
               print("SKIP")
               sys.exit(0)
 
-          # Extract keys (suite names) — simple approach: grab all quoted keys
+          # Extract keys (suite names) -- simple approach: grab all quoted keys
           keys = re.findall(r'^\s{4}["\']([a-z0-9_]+)["\']', m.group(0), re.MULTILINE)
           if not keys:
               print("SKIP")

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,21 @@
+# Claude Code — Project Guidelines
+
+## Git Workflow
+
+- **Always use the PR workflow.** Never push directly to main.
+- Make changes on a feature branch, push the branch, open a PR.
+- Wait for user approval before merging unless explicitly told to merge directly.
+- Use descriptive branch names: `feature/...`, `fix/...`, `release/...`
+
+## Repository
+
+- GitHub repo: `jdibby/traffgen`
+- Default branch: `main`
+- Use `mcp__github__push_files` or branch pushes + PR for all merges to main.
+
+## Versioning
+
+- Follows semantic versioning: `MAJOR.MINOR.PATCH`
+- Current version defined in `generator.py` → `VERSION` constant and module docstring.
+- Minor releases (`x.Y.0`) for bug fixes, doc updates, and small features.
+- Major releases (`X.0.0`) for breaking changes or large new feature sets.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,6 +13,16 @@
 - Default branch: `main`
 - Use `mcp__github__push_files` or branch pushes + PR for all merges to main.
 
+## CI / Docker Hub
+
+- Every merge to `main` triggers a GitHub Actions build that publishes a multi-arch
+  Docker image (`linux/amd64`, `linux/arm64`, `linux/arm/v7`) to Docker Hub as
+  `jdibby/traffgen:latest` and `jdibby/traffgen:<sha>`.
+- After a PR merges, check that the Docker build CI job passes.
+- A second workflow (`docs-check.yml`) runs on PRs that touch `generator.py`,
+  `README.md`, or `docs/**` — it emits warnings if suite names or the version
+  number are missing from `README.md`.
+
 ## Versioning
 
 - Follows semantic versioning: `MAJOR.MINOR.PATCH`

--- a/generator.py
+++ b/generator.py
@@ -543,8 +543,7 @@ def _web_flush() -> None:
     """Atomically write _WEB_STATE (minus private keys) to the state file."""
     tmp = _WEB_STATE_FILE + ".tmp"
     try:
-        with _WEB_STATE_LOCK:
-            snapshot = {k: v for k, v in _WEB_STATE.items() if not k.startswith("_")}
+        snapshot = {k: v for k, v in _WEB_STATE.items() if not k.startswith("_")}
         with open(tmp, "w") as f:
             json.dump(snapshot, f, separators=(",", ":"))
         os.replace(tmp, _WEB_STATE_FILE)
@@ -620,7 +619,7 @@ def _web_record(name: str, ok: bool, dur_ms: int,
                 _WEB_STATE["history"] = _WEB_STATE["history"][-120:]
             _WEB_STATE["_history_last_t"] = now
 
-        _web_flush()
+    _web_flush()
 
 
 def _web_log(msg: str, level: str = "info", test: str = "") -> None:


### PR DESCRIPTION
## Summary

- **Root cause:** v3.4.0 added `with _WEB_STATE_LOCK:` inside `_web_flush()` to fix a race condition, but `_web_flush()` is called from *within* the `_WEB_STATE_LOCK` block in `_web_record()`. Python's `threading.Lock` is not reentrant — the same thread blocks on its own lock after the first test completes, freezing the entire state pipeline.
- **Symptom:** Every dashboard widget showed "Waiting..." / "No data yet" after the container started — Overview, Security, and all other tabs.
- **Fix:** Revert `_web_flush()` to not acquire the lock; move its call in `_web_record()` outside the `with` block so file I/O no longer holds the state lock.

## Test plan

- [ ] Start container and confirm dashboard widgets populate after the first test suite completes
- [ ] Confirm Security tab shows probe counts / blocked / dropped / allowed
- [ ] Confirm Overview tab shows test breakdown table and live events

https://claude.ai/code/session_01QiHkJ7DeFEB7bsfFW93bXW

---
_Generated by [Claude Code](https://claude.ai/code/session_01QiHkJ7DeFEB7bsfFW93bXW)_