### PR TITLE
feat: per-probe drill-down on Security tab (v3.5.0) [superseded by #272]

### DIFF
--- a/generator.py
+++ b/generator.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 """
-generator.py — Traffic Generator v3.4.0
+generator.py — Traffic Generator v3.5.0
 ========================================
 Simulates realistic network traffic across a wide range of protocols and
 behaviours: DNS, HTTP/HTTPS/HTTP3, FTP, SSH, NTP, BGP, ICMP, SNMP,
@@ -58,7 +58,7 @@ from rich import box
 from endpoints import *           # noqa: F401,F403  (large data file)
 
 # ── Globals ───────────────────────────────────────────────────────────────────
-VERSION = "3.4.0"
+VERSION = "3.5.0"
 
 
 class _DualWriter:
@@ -341,57 +341,71 @@ class SuiteStats:
         self.blocked    = 0   # security control intercept
         self.dropped    = 0   # silent drop / timeout / DNS sinkhole
         self.codes: dict[str, int] = {}
+        self.probes: list[dict] = []  # per-probe details for drill-down
         self.start_time = time.time()
 
-    def record(self, code, exit_code: int = 0) -> None:
+    def record(self, code, exit_code: int = 0, target: str = "") -> None:
         """Record an HTTP status code (and optional curl exit code).
         '---' / '000' / '' counts as a drop/error."""
         with self._lock:
             self.attempts += 1
             c = str(code).strip()
             if exit_code in _BLOCK_EXITS:
+                outcome = "blocked"
                 self.blocked += 1
                 bucket = f"exit{exit_code}"
                 self.codes[bucket] = self.codes.get(bucket, 0) + 1
             elif exit_code in _DROP_EXITS:
+                outcome = "dropped"
                 self.dropped += 1
                 self.errors  += 1   # keep errors count for backwards compat
             elif not c or c in ("---", "000", "0"):
+                outcome = "dropped"
                 self.dropped += 1
                 self.errors  += 1
             elif c in _BLOCK_HTTP:
+                outcome = "blocked"
                 self.blocked += 1
                 self.responses += 1
                 bucket = (c[0] + "xx") if c[:1].isdigit() else c[:3]
                 self.codes[bucket] = self.codes.get(bucket, 0) + 1
             else:
+                outcome = "allowed"
                 self.allowed   += 1
                 self.responses += 1
                 bucket = (c[0] + "xx") if c[:1].isdigit() else c[:3]
                 self.codes[bucket] = self.codes.get(bucket, 0) + 1
+            if target and len(self.probes) < _PROBE_DETAIL_MAX:
+                self.probes.append({"t": target, "o": outcome, "c": c})
 
-    def ok(self) -> None:
+    def ok(self, target: str = "") -> None:
         """Record a successful non-HTTP probe (ping, dig, SSH reached, etc.)."""
         with self._lock:
             self.attempts  += 1
             self.responses += 1
             self.allowed   += 1
+            if target and len(self.probes) < _PROBE_DETAIL_MAX:
+                self.probes.append({"t": target, "o": "allowed", "c": ""})
 
-    def fail(self) -> None:
+    def fail(self, target: str = "") -> None:
         """Record a failed probe (exception, timeout, unreachable)."""
         with self._lock:
             self.attempts += 1
             self.errors   += 1
+            if target and len(self.probes) < _PROBE_DETAIL_MAX:
+                self.probes.append({"t": target, "o": "dropped", "c": ""})
 
-    def block(self, exit_code: int = 7) -> None:
+    def block(self, exit_code: int = 7, target: str = "") -> None:
         """Record an explicit non-HTTP block (RST, proxy refusal detected externally)."""
         with self._lock:
             self.attempts += 1
             self.blocked  += 1
             bucket = f"exit{exit_code}"
             self.codes[bucket] = self.codes.get(bucket, 0) + 1
+            if target and len(self.probes) < _PROBE_DETAIL_MAX:
+                self.probes.append({"t": target, "o": "blocked", "c": bucket})
 
-    def drop(self, exit_code: int = 28) -> None:
+    def drop(self, exit_code: int = 28, target: str = "") -> None:
         """Record a silent drop (timeout, no route, DNS sinkhole)."""
         with self._lock:
             self.attempts += 1
@@ -399,6 +413,8 @@ class SuiteStats:
             self.errors   += 1
             bucket = f"exit{exit_code}"
             self.codes[bucket] = self.codes.get(bucket, 0) + 1
+            if target and len(self.probes) < _PROBE_DETAIL_MAX:
+                self.probes.append({"t": target, "o": "dropped", "c": bucket})
 
     def merge(self, other: "SuiteStats") -> None:
         """Accumulate counters from another SuiteStats instance into this one."""
@@ -464,6 +480,7 @@ class SuiteStats:
         ))
 
 
+_PROBE_DETAIL_MAX = 200        # max per-probe entries kept per suite run
 _stats       = SuiteStats()   # per-function stats, reset before each function
 _suite_stats = SuiteStats()   # aggregate across all functions in a suite run
 
@@ -553,14 +570,15 @@ def _web_flush() -> None:
 
 def _web_record(name: str, ok: bool, dur_ms: int,
                 responses: int = 0, codes: "dict | None" = None,
-                blocked: int = 0, dropped: int = 0, allowed: int = 0) -> None:
+                blocked: int = 0, dropped: int = 0, allowed: int = 0,
+                probe_detail: "list | None" = None) -> None:
     """Record one completed test run into the web state and flush to disk."""
     with _WEB_STATE_LOCK:
         t = _WEB_STATE["tests"].setdefault(name, {
             "attempts": 0, "ok": 0, "fail": 0, "responses": 0,
             "last_run_at": 0, "last_ok": True,
             "last_dur_ms": 0, "avg_dur_ms": 0, "codes": {},
-            "blocked": 0, "dropped": 0, "allowed": 0,
+            "blocked": 0, "dropped": 0, "allowed": 0, "probes": [],
         })
         t["attempts"]   += 1
         t["responses"]  += responses
@@ -585,6 +603,11 @@ def _web_record(name: str, ok: bool, dur_ms: int,
         # Accumulate HTTP response-code buckets
         for code, cnt in (codes or {}).items():
             t["codes"][code] = t["codes"].get(code, 0) + cnt
+
+        # Per-probe drill-down: keep last _PROBE_DETAIL_MAX entries across runs
+        if probe_detail:
+            combined = t.get("probes", []) + probe_detail
+            t["probes"] = combined[-_PROBE_DETAIL_MAX:]
 
         # Clear running indicators
         _WEB_STATE["test_started_at"] = 0.0
@@ -881,7 +904,8 @@ def _run_guarded(func) -> None:
     dur_ms = int((time.time() - t0) * 1000)
     run_ok = not exc_box and not t.is_alive()
     _web_record(suite_name, run_ok, dur_ms, _stats.responses, dict(_stats.codes),
-                blocked=_stats.blocked, dropped=_stats.dropped, allowed=_stats.allowed)
+                blocked=_stats.blocked, dropped=_stats.dropped, allowed=_stats.allowed,
+                probe_detail=list(_stats.probes))
     _web_log(
         f"{suite_name}: {_stats.attempts} attempts, "
         f"{_stats.responses} ok, {_stats.errors} fail — {dur_ms}ms",
@@ -921,10 +945,10 @@ def _run_head_batch(urls: list[str], label: str,
                 status, exit_code = _curl_head(url, ua, connect_timeout, max_time, extra_flags)
                 style  = _status_style(status)
                 console.log(f"[{idx}/{len(urls)}] {url}  [{style}]HTTP {status}[/]")
-                _stats.record(status, exit_code)
+                _stats.record(status, exit_code, target=url)
             except Exception as e:
                 console.log(f"[yellow][{idx}/{len(urls)}] {url}  {e.__class__.__name__}[/]")
-                _stats.fail()
+                _stats.fail(target=url)
             finally:
                 prog.update(task, advance=1)
 

--- a/webui.py
+++ b/webui.py
@@ -1221,6 +1221,8 @@ td.nm{font-family:inherit;font-weight:500;font-size:16px}
 .bf{height:100%;border-radius:2px;transition:width .4s}
 .xrow{display:none}
 .xrow.open{display:table-row}
+.sec-probe-row{background:var(--surf2)}
+.sec-probe-cell{padding:4px 14px 4px 32px;font-family:'SF Mono',Consolas,monospace;font-size:13px;border-bottom:1px solid var(--border);word-break:break-all}
 .xcell{padding:7px 12px 9px 26px;background:var(--surf2);font-size:15px;font-family:'SF Mono',Consolas,monospace;border-bottom:1px solid var(--border)}
 .xinner{display:flex;flex-wrap:wrap;gap:14px}
 .xi{display:flex;flex-direction:column;gap:2px}
@@ -2287,7 +2289,7 @@ function _hideWaitBanner(){
 }
 (()=>{const ob=$('obody');if(!ob)return;ob.addEventListener('scroll',()=>{if(_scrollLock)return;const gap=ob.scrollHeight-ob.scrollTop-ob.clientHeight;const atBot=gap<120;if(atBot&&!_autoScroll){_autoScroll=true;const b=$('btn-as');if(b)b.innerHTML='Auto-scroll &#10003;';}else if(!atBot&&_autoScroll){_autoScroll=false;const b=$('btn-as');if(b)b.innerHTML='Auto-scroll &#10007;';}},{passive:true});})();
 let _lastState=null,_logEs=null,_logFilter='all';
-let _xRows=new Set(),_xEvs=new Set(),_modalSuite=null,_isPaused=false,_lastTest=null;
+let _xRows=new Set(),_xEvs=new Set(),_xSecRows=new Set(),_modalSuite=null,_isPaused=false,_lastTest=null;
 let _SD={};  // suite name → description, populated on first state arrival
 let _isAdmin=true,_authRequired=false,_adminToken='',_sessionMode=false,_hasController=false;
 let _sessionId=(()=>{try{let s=sessionStorage.getItem('tg-sid');if(!s){s=crypto.randomUUID();sessionStorage.setItem('tg-sid',s);}return s;}catch(e){return '';}})();
@@ -2734,6 +2736,7 @@ function apply(s){
 }
 function toggleRow(n){if(_xRows.has(n))_xRows.delete(n);else _xRows.add(n);if(_lastState)apply(_lastState);}
 function toggleEv(i){if(_xEvs.has(i))_xEvs.delete(i);else _xEvs.add(i);if(_lastState)apply(_lastState);}
+function toggleSecRow(n){if(_xSecRows.has(n))_xSecRows.delete(n);else _xSecRows.add(n);updateSecurityTab();}
 function connect(){
   const url='/events'+(_sessionId?'?sid='+encodeURIComponent(_sessionId):'');
   const es=new EventSource(url);
@@ -3240,7 +3243,7 @@ function updateSecurityTab(){
   }
   drawSecTrend(_secHist);
   // per-suite table — sort by blocked desc
-  const rows=Object.entries(tests).map(([n,t])=>({n,ta:t.attempts||0,rch:t.allowed||0,blk:t.blocked||0,drp:t.dropped||0,tot:(t.allowed||0)+(t.blocked||0)+(t.dropped||0)}));
+  const rows=Object.entries(tests).map(([n,t])=>({n,t,ta:t.attempts||0,rch:t.allowed||0,blk:t.blocked||0,drp:t.dropped||0,tot:(t.allowed||0)+(t.blocked||0)+(t.dropped||0),probes:t.probes||[]}));
   rows.sort((a,b)=>b.blk-a.blk||(b.drp-a.drp));
   const tb=$('sec-tbl');
   if(!rows.length){tb.innerHTML='<tr><td colspan="7" class="empty">Waiting…</td></tr>';}
@@ -3248,7 +3251,17 @@ function updateSecurityTab(){
     const bp=r.tot?r.blk/r.tot*100:0,dp=r.tot?r.drp/r.tot*100:0;
     const bpC=bp>50?'var(--red)':bp>10?'var(--amber)':'var(--muted)';
     const dpC=dp>50?'var(--red)':dp>10?'#818cf8':'var(--muted)';
-    return`<tr class="mrow"><td class="nm" title="${_SD[r.n]||''}" style="cursor:default"><span class="s-ico">${suiteIco(r.n)}</span>${H(r.n)}</td><td class="r">${N(r.tot)}</td><td class="r" style="color:#22c55e">${N(r.rch)}</td><td class="r" style="color:var(--amber)">${N(r.blk)}</td><td class="r" style="color:#818cf8">${N(r.drp)}</td><td class="r"><span style="color:${bpC}">${r.tot?bp.toFixed(1)+'%':'—'}</span></td><td class="r"><span style="color:${dpC}">${r.tot?dp.toFixed(1)+'%':'—'}</span></td></tr>`;
+    const hasProbes=r.probes.length>0,exp=_xSecRows.has(r.n);
+    const chevron=hasProbes?`<span class="chev${exp?' open':''}" style="margin-right:4px">&#8250;</span>`:'';
+    const mainRow=`<tr class="mrow"${hasProbes?` onclick="toggleSecRow('${r.n}')"`:' style="cursor:default"'}><td class="nm" title="${_SD[r.n]||''}">${chevron}<span class="s-ico">${suiteIco(r.n)}</span>${H(r.n)}</td><td class="r">${N(r.tot)}</td><td class="r" style="color:#22c55e">${N(r.rch)}</td><td class="r" style="color:var(--amber)">${N(r.blk)}</td><td class="r" style="color:#818cf8">${N(r.drp)}</td><td class="r"><span style="color:${bpC}">${r.tot?bp.toFixed(1)+'%':'—'}</span></td><td class="r"><span style="color:${dpC}">${r.tot?dp.toFixed(1)+'%':'—'}</span></td></tr>`;
+    if(!hasProbes)return mainRow;
+    const probeRows=r.probes.map(p=>{
+      const oC=p.o==='allowed'?'#22c55e':p.o==='blocked'?'var(--amber)':'#818cf8';
+      const codeStr=p.c?` <span style="color:var(--muted);font-size:13px">(${H(p.c)})</span>`:'';
+      return`<tr class="sec-probe-row"><td colspan="7" class="sec-probe-cell"><span style="color:${oC};font-weight:600;min-width:60px;display:inline-block">${H(p.o)}</span> <span style="color:var(--text)">${H(p.t)}</span>${codeStr}</td></tr>`;
+    }).join('');
+    const detailRow=`<tr class="xrow${exp?' open':''}"><td colspan="7" class="xcell" style="padding:0"><table style="width:100%;border-collapse:collapse">${probeRows}</table></td></tr>`;
+    return mainRow+detailRow;
   }).join('');
   // block signal breakdown — aggregate codes across filtered tests
   const codeTotals={};


### PR DESCRIPTION
## Summary

- Clicking a suite row in the **Security → Per-Suite Breakdown** table now expands an inline list of every probe recorded in that suite's last run, showing the target URL, outcome (**allowed** / **blocked** / **dropped**), and HTTP/exit code
- Rows with no probe data (non-HTTP suites) are not clickable and show no chevron
- The expand state persists while the tab is open and re-renders on each refresh
- Bumps version to **v3.5.0**

## What changed

**generator.py**
- `SuiteStats._reset()`: adds `self.probes: list[dict]` — compact `{t, o, c}` entries
- `SuiteStats.record() / ok() / fail() / block() / drop()`: each accept an optional `target: str` param; when provided, append a probe entry (capped at `_PROBE_DETAIL_MAX = 200`)
- `_run_head_batch._worker()`: passes `target=url` to `_stats.record()` and `fail()` so all HTTP-batch suites get full drill-down automatically
- `_web_record()`: accepts `probe_detail` kwarg; appends to `_WEB_STATE["tests"][name]["probes"]` (rolling 200-entry cap across runs)
- `_run_guarded()`: passes `probe_detail=list(_stats.probes)` to `_web_record()`

**webui.py**
- Security breakdown table rows become clickable when probe data is available (chevron indicator)
- Expanded row renders a colour-coded sub-table: <span style="color:green">allowed</span>, <span style="color:orange">blocked</span>, <span style="color:purple">dropped</span>
- `_xSecRows` Set tracks expand state; `toggleSecRow()` toggles and re-renders the tab
- `.sec-probe-cell` CSS for the sub-row styling

## Test plan
- [ ] Run malware or pornography suite; open Security tab; click suite row — should show probe URLs with colour-coded outcomes
- [ ] Suites without HTTP probes (e.g. bgp_peering, ping) show no chevron and are not clickable
- [ ] Expand/collapse toggles correctly on repeat clicks
- [ ] Block% / Drop% columns and totals unchanged

https://claude.ai/code/session_01QiHkJ7DeFEB7bsfFW93bXW

---
_Generated by [Claude Code](https://claude.ai/code/session_01QiHkJ7DeFEB7bsfFW93bXW)_