### PR TITLE
fix: resolve JS SyntaxError at rendered line 1185 (ovJump/showTab undefined)

### DIFF
--- a/webui.py
+++ b/webui.py
@@ -2297,7 +2297,7 @@ const RC=p=>p>=90?'var(--green)':p>=70?'var(--amber)':'var(--red)';
 // -- Column sort --------------------------------------------------------------
 const _tblSort={};
 function _parseSortVal(txt){
-  const s=(txt||'').trim().split(/\n/)[0].trim();
+  const s=(txt||'').trim().split(/\\n/)[0].trim();
   let m;
   if(s==='\u2014'||s==='')return Infinity;
   if((m=s.match(/^(?:(\d+)d\s+)?(\d+)h\s+(\d+)m$/)))return(parseInt(m[1]||0)*86400+parseInt(m[2])*3600+parseInt(m[3])*60);


### PR DESCRIPTION
## Root cause

`_HTML` is a regular Python `"""` triple-quoted string. Python expands `\n` inside it to a real newline **before** the browser ever sees the JS.

The `_parseSortVal` function had:
```js
const s=(txt||'').trim().split(/\n/)[0].trim();
```

Python expanded `\n` → actual newline, so the browser received:
```js
const s=(txt||'').trim().split(/
/)[0].trim();
```

A regex literal can't span lines → **`Uncaught SyntaxError: Invalid regular expression: missing /`** at rendered line 1185. Because the entire script block failed to parse, `ovJump` and `showTab` were never defined — breaking all navigation clicks.

## Fix

Change `\n` → `\\n` in the Python source so Python outputs the literal two-character sequence `\n` to the browser:

```python
# Before (Python expands \n to real newline):
const s=(txt||'').trim().split(/\n/)[0].trim();

# After (Python outputs literal \n escape):
const s=(txt||'').trim().split(/\\n/)[0].trim();
```

One line changed.

https://claude.ai/code/session_01QiHkJ7DeFEB7bsfFW93bXW

---
_Generated by [Claude Code](https://claude.ai/code/session_01QiHkJ7DeFEB7bsfFW93bXW)_