### PR TITLE
fix: Live View UA condensing, log level classification, sub-result indent (v3.8.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [![Docker Hub](https://img.shields.io/docker/pulls/jdibby/traffgen?logo=docker&label=Docker%20Hub)](https://hub.docker.com/r/jdibby/traffgen)
 [![Multi-arch](https://img.shields.io/badge/arch-amd64%20%7C%20arm64%20%7C%20arm%2Fv7-blue?logo=linux)](https://hub.docker.com/r/jdibby/traffgen)
-[![Version](https://img.shields.io/badge/version-3.7.0-green)](https://github.com/jdibby/traffgen/blob/main/generator.py)
+[![Version](https://img.shields.io/badge/version-3.8.0-green)](https://github.com/jdibby/traffgen/blob/main/generator.py)
 
 Trafgen simulates realistic network traffic across **52 test suites** — DNS, HTTP/S, FTP, SSH, BGP, ICMP, NTP, SNMP, DoH, DoT, VoIP/UCaaS, C2 beacons, DNS exfiltration, AI/LLM DLP, lateral movement, TLS inspection checks, WAF attacks, and more.
 

--- a/generator.py
+++ b/generator.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 """
-generator.py — Traffic Generator v3.7.0
+generator.py — Traffic Generator v3.8.0
 ========================================
 Simulates realistic network traffic across a wide range of protocols and
 behaviours: DNS, HTTP/HTTPS/HTTP3, FTP, SSH, NTP, BGP, ICMP, SNMP,
@@ -58,7 +58,7 @@ from rich import box
 from endpoints import *           # noqa: F401,F403  (large data file)
 
 # ── Globals ───────────────────────────────────────────────────────────────────
-VERSION = "3.7.0"
+VERSION = "3.8.0"
 
 
 class _DualWriter:
@@ -121,6 +121,21 @@ class _DualWriter:
             lvl = 'warn'
         elif re.match(r'^[─━]{4,}', line):
             lvl = 'rule'
+        elif re.search(
+            r'(?i)\b(connection\s*error|connection\s*refused|connection\s*reset'
+            r'|no\s+links?\s+found|timed?\s*out|timeout|ssl\s*error'
+            r'|unreachable|skipping|skipped|blocked|dropped'
+            r'|HTTP\s+[45]\d{2}|→\s+[45]\d{2}'
+            r'|^\s*[45]\d{2}\b)',
+            line,
+        ):
+            lvl = 'warn'
+        elif re.search(
+            r'(?i)\b(exception|traceback|error\s*:|failed|failure'
+            r'|crash|abort|fatal|critical)\b',
+            line,
+        ):
+            lvl = 'error'
         else:
             lvl = 'info'
         _web_log(line, level=lvl)
@@ -747,6 +762,40 @@ def _size_to_limits(size: str, s, m, l, xl, *, xs=None):
 # ══════════════════════════════════════════════════════════════════════════════
 # BROWSER HEADER SIMULATION
 # ══════════════════════════════════════════════════════════════════════════════
+
+def _short_ua(ua: str) -> str:
+    """Return a compact [Browser/OS] label from a User-Agent string."""
+    ul = ua.lower()
+    os = ""
+    am = re.search(r'android (\d+)', ul)
+    if am:
+        os = f"Android {am.group(1)}"
+    elif re.search(r'iphone os (\d+)', ul):
+        m = re.search(r'iphone os (\d+)', ul)
+        os = f"iOS {m.group(1)}"
+    elif re.search(r'windows nt', ul):
+        os = "Windows"
+    elif "macintosh" in ul:
+        os = "macOS"
+    elif "linux" in ul:
+        os = "Linux"
+    br = ""
+    if "edg/" in ul or "edga/" in ul:
+        m = re.search(r'edg[a/](\d+)', ul)
+        br = f"Edge/{m.group(1)}" if m else "Edge"
+    elif "chrome/" in ul and "chromium" not in ul:
+        m = re.search(r'chrome/(\d+)', ul)
+        br = f"Chrome/{m.group(1)}" if m else "Chrome"
+    elif "firefox/" in ul:
+        m = re.search(r'firefox/(\d+)', ul)
+        br = f"Firefox/{m.group(1)}" if m else "Firefox"
+    elif "safari/" in ul:
+        m = re.search(r'version/(\d+)', ul)
+        br = f"Safari/{m.group(1)}" if m else "Safari"
+    else:
+        br = "Browser"
+    return f"[{br}/{os}]" if os else f"[{br}]"
+
 
 def _browser_headers_dict(ua: str) -> dict:
     """Return a dict of HTTP headers that match the given user-agent string.
@@ -2968,7 +3017,7 @@ def c2_beacon() -> None:
                 jitter  = random.uniform(1, 5)
                 console.log(
                     f"C2 ({i}/{beacons}) POST → {target}  "
-                    f"jitter={jitter:.1f}s  ua={ua[:40]}"
+                    f"jitter={jitter:.1f}s  ua={_short_ua(ua)}"
                 )
                 try:
                     resp = requests.post(
@@ -3577,7 +3626,7 @@ def scrape_single_link(url: str) -> str | None:
     """
     time.sleep(random.uniform(0.2, 2))
     ua = random.choice(user_agents)
-    console.log(f"→ {url}  [dim]{ua[:60]}[/]")
+    console.log(f"→ {url}  [dim]{_short_ua(ua)}[/]")
 
     try:
         resp = requests.get(

--- a/webui.py
+++ b/webui.py
@@ -2159,6 +2159,16 @@ docker run --pull=always -it jdibby/traffgen:latest --suite=dns --size=L</div>
       <div style="max-width:900px">
 
         <div class="a-section">
+          <div class="a-h">v3.8.0 &mdash; <span style="color:var(--muted);font-weight:400">May 2026</span></div>
+          <table class="st-table" style="margin-top:10px">
+            <tr><th style="width:80px">Type</th><th style="width:140px">Area</th><th>Description</th></tr>
+            <tr><td><span class="cl-fix">FIX</span></td><td>Live View</td><td><strong>UA label wrapping</strong> — log lines containing User-Agent strings are now condensed to compact labels (e.g. <code>[Chrome/130/Android 14]</code>) in both the generator and the web UI, preventing long UAs from splitting across multiple log entries</td></tr>
+            <tr><td><span class="cl-fix">FIX</span></td><td>Live View</td><td><strong>Log level classification</strong> — connection errors, timeouts, "no links found", HTTP 4xx/5xx responses, and other failure signals are now classified as <code>WARN</code> or <code>ERROR</code> instead of <code>INFO</code></td></tr>
+            <tr><td><span class="cl-fix">FIX</span></td><td>Live View</td><td><strong>Sub-result indentation</strong> — log lines prefixed with <code>↳</code> (sub-results / follow-up detail lines) now render with proportional left padding in the web Live View, matching the visual nesting shown in the terminal</td></tr>
+          </table>
+        </div>
+
+        <div class="a-section">
           <div class="a-h">v3.7.0 &mdash; <span style="color:var(--muted);font-weight:400">May 2026</span></div>
           <table class="st-table" style="margin-top:10px">
             <tr><th style="width:80px">Type</th><th style="width:140px">Area</th><th>Description</th></tr>
@@ -3093,7 +3103,7 @@ function setFilter(btn,lvl){
   });
 }
 function _fmtMsgUA(msg){
-  return msg.replace(/Mozilla\/5\.0[^\s"']*(?:\([^)]*\)[^\s"']*)*/g,function(ua){
+  return msg.replace(/Mozilla\/5\.0[^"'\n]*/g,function(ua){
     let os='';
     const am=ua.match(/Android (\d+(?:\.\d+)*)/);if(am)os='Android '+am[1];
     else{const im=ua.match(/iPhone OS (\d+[_\d]*)/);if(im)os='iOS '+im[1].replace(/_/g,'.');}
@@ -3139,6 +3149,8 @@ function appendLog(d){
     div.innerHTML=`<span class="llt">${ts}</span><span class="llm">${H(msg)}</span>`;
   } else {
     div.className='ll '+lvl;
+    const _im=msg.match(/^( +)↳/);
+    if(_im)div.style.paddingLeft=(14+Math.min(_im[1].length,8)*8)+'px';
     const icon=lvl==='ok'?'✔ ':lvl==='error'?'✗ ':lvl==='warn'?'⚠ ':'';
     div.innerHTML=`<span class="llt">${ts}</span><span class="llv">${H(lvl.toUpperCase().slice(0,5).padEnd(5))}</span><span class="llm">${icon?`<span style="opacity:.7">${icon}</span>`:''}${H(_fmtMsgUA(msg))}</span>`;
   }
@@ -3752,6 +3764,8 @@ function _odrAppendLine(body,raw){
   else if(/\[warn\]|⚠|\bwarn(ing)?\b/i.test(raw))lvl='warn';
   const icon=lvl==='ok'?'✔ ':lvl==='error'?'✗ ':lvl==='warn'?'⚠ ':'';
   div.className='ll '+lvl;
+  const _im2=raw.match(/^( +)↳/);
+  if(_im2)div.style.paddingLeft=(14+Math.min(_im2[1].length,8)*8)+'px';
   div.innerHTML='<span class="llt">'+ts+'</span><span class="llv">'+H(lvl.toUpperCase().slice(0,5).padEnd(5))+'</span><span class="llm">'+(icon?'<span style="opacity:.7">'+icon+'</span>':'')+H(_fmtMsgUA(raw))+'</span>';
   body.appendChild(div);body.scrollTop=body.scrollHeight;
 }


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **UA condensing** — `_short_ua()` helper in generator.py converts full UA strings (e.g. `Mozilla/5.0 (Linux; Android 14; SM-S926U) AppleWebKit/537.36 ...`) to compact `[Chrome/130/Android 14]` labels in log statements, so long UAs no longer wrap and split into multiple separate log entries in the Live View
- **Log level classification** — `_DualWriter._flush_line()` now detects ConnectionError, timeout, "no links found", HTTP 4xx/5xx, and similar failure signals and emits them as `WARN` or `ERROR` instead of `INFO`
- **`_fmtMsgUA` regex fix** — updated the webui.py regex from `Mozilla\/5\.0[^\s"']*...` to `Mozilla\/5\.0[^"'\n]*` so the full UA string is matched and replaced, not just the `Mozilla/5.0` prefix
- **Sub-result indentation** — `appendLog` detects lines with leading spaces + `↳` and applies proportional `padding-left`, so sub-result lines appear visually nested in the Live View matching the terminal output
- Version bumped to 3.8.0

## Test plan

- [ ] Run HTTPS crawl suite — verify log lines show `[Chrome/130/Android 14]` style labels, not raw UAs
- [ ] Confirm no UA text wraps across multiple log entries
- [ ] Verify ConnectionError, timeout, "no links found" lines show as WARN (amber) not INFO (blue)
- [ ] Verify HTTP 404/403/500 results show as WARN
- [ ] Check `↳` sub-result lines appear indented relative to the parent log line
- [ ] Confirm Live View pop-out window also shows correct indentation

https://claude.ai/code/session_01QiHkJ7DeFEB7bsfFW93bXW
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QiHkJ7DeFEB7bsfFW93bXW)_