### PR TITLE
fix: escape \\n in _fmtMsgUA regex — resolves JS SyntaxError

### DIFF
--- a/webui.py
+++ b/webui.py
@@ -3103,7 +3103,7 @@ function setFilter(btn,lvl){
   });
 }
 function _fmtMsgUA(msg){
-  return msg.replace(/Mozilla\/5\.0[^"'\n]*/g,function(ua){
+  return msg.replace(/Mozilla\/5\.0[^"'\\n]*/g,function(ua){
     let os='';
     const am=ua.match(/Android (\d+(?:\.\d+)*)/);if(am)os='Android '+am[1];
     else{const im=ua.match(/iPhone OS (\d+[_\d]*)/);if(im)os='iOS '+im[1].replace(/_/g,'.');}


### PR DESCRIPTION
Regression introduced in v3.8.0 (#283).

The `_fmtMsgUA` regex change used `\n` inside a Python string, which Python expands to a literal newline before the JavaScript reaches the browser. This breaks the regex (`Invalid regular expression: missing /`) and prevents all subsequent JS from loading, making the UI unclickable.

Fix: use `\\n` in the Python source so the browser receives the literal two-character sequence `\n` as intended.

https://claude.ai/code/session_01QiHkJ7DeFEB7bsfFW93bXW

---
_Generated by [Claude Code](https://claude.ai/code/session_01QiHkJ7DeFEB7bsfFW93bXW)_