### PR TITLE
v3.9.1: iperf3 suite restored + diagnostics rework + wider login card

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 
 [![Docker Hub](https://img.shields.io/docker/pulls/jdibby/traffgen?logo=docker&label=Docker%20Hub)](https://hub.docker.com/r/jdibby/traffgen)
 [![Multi-arch](https://img.shields.io/badge/arch-amd64%20%7C%20arm64%20%7C%20arm%2Fv7-blue?logo=linux)](https://hub.docker.com/r/jdibby/traffgen)
-[![Version](https://img.shields.io/badge/version-3.9.0-green)](https://github.com/jdibby/traffgen/blob/main/generator.py)
+[![Version](https://img.shields.io/badge/version-3.9.1-green)](https://github.com/jdibby/traffgen/blob/main/generator.py)
 
-Trafgen simulates realistic network traffic across **52 test suites** — DNS, HTTP/S, FTP, SSH, BGP, ICMP, NTP, SNMP, DoH, DoT, VoIP/UCaaS, C2 beacons, DNS exfiltration, AI/LLM DLP, lateral movement, TLS inspection checks, WAF attacks, and more.
+Trafgen simulates realistic network traffic across **53 test suites** — DNS, HTTP/S, FTP, SSH, BGP, ICMP, NTP, SNMP, DoH, DoT, VoIP/UCaaS, C2 beacons, DNS exfiltration, AI/LLM DLP, lateral movement, TLS inspection checks, WAF attacks, iperf3 bandwidth, and more.
 
 Purpose-built to validate **firewalls**, **IDS/IPS**, **URL filters**, **DLP engines**, **CASB platforms**, and **SIEM pipelines**.
 
@@ -58,7 +58,7 @@ curl -sk https://raw.githubusercontent.com/jdibby/traffgen/refs/heads/main/stage
 
 | Doc | What's in it |
 |---|---|
-| [Test Suites](docs/suites.md) | All 52 suites — what each tests, how to interpret results, outcome classification |
+| [Test Suites](docs/suites.md) | All 53 suites — what each tests, how to interpret results, outcome classification |
 | [Deployment Guide](docs/deployment.md) | Docker commands, stager.sh, network modes, TLS proxy setup, architecture, building |
 | [Configuration](docs/configuration.md) | CLI flags, `--size`, traffic pacing, custom endpoints |
 | [Web Dashboard](docs/web-dashboard.md) | Dashboard tabs, controls, draggable widgets, chart hover, multi-user mode |

--- a/docs/suites.md
+++ b/docs/suites.md
@@ -1,6 +1,6 @@
 # Test Suites
 
-Traffgen ships **52 test suites** covering every major protocol and security control category. Use `--suite=<name>` to run a specific suite, or `--suite=all` to run every suite in shuffled order.
+Traffgen ships **53 test suites** covering every major protocol and security control category. Use `--suite=<name>` to run a specific suite, or `--suite=all` to run every suite in shuffled order.
 
 ```bash
 docker run --pull=always -it jdibby/traffgen:latest --list
@@ -69,6 +69,7 @@ docker run --pull=always -it jdibby/traffgen:latest --list
 | 🌐 `msf-webapp` | Metasploit **check-mode probes for web application CVEs**: Drupal Drupalgeddon2 (CVE-2018-7600) and Drupalgeddon3 (CVE-2018-7602), Joomla HTTP header RCE (CVE-2015-8562), WordPress RevSlider arbitrary file upload, GitLab arbitrary file read via ExifTool injection (CVE-2021-22205), PHP CGI argument injection (CVE-2024-4577/CVE-2012-1823), Magento Shoplift SQL injection (CVE-2015-1397), and Webmin Package Update RCE (CVE-2019-12840). |
 | 💥 `log4shell` | Injects **Log4Shell (CVE-2021-44228) JNDI payloads** into six HTTP request headers using LDAP, RMI, DNS, and obfuscated `${lower:}` / `${::-}` bypass variants. Targets testmyids.com and OWASP Juice Shop. Triggers Suricata SID 2034907/2034908 (ET EXPLOIT Log4j) and WAF header-injection rules. |
 | 🛑 `waf-attack` | Sends **18 WAF-targeting attack payloads** in URL query parameters and POST bodies: SQLi (union/error/blind/sleep), XSS (script/img/svg), LFI (path traversal), SSRF (AWS metadata + localhost), OS command injection (semicolon/pipe/backtick), XXE (external entity), and SSTI (Jinja2/Twig). |
+| 📶 `iperf3` | Sends a **1 Mbps UDP stream** to a set of well-known public iperf3 servers on port 5201. Size controls how many servers are tested: XS=1, S=2, M=3, L=4, XL=all 5. Each test runs for 10 seconds. Validates egress UDP on port 5201, bulk UDP flow detection, bandwidth-anomaly rules, and QoS/rate-limiting policies. |
 | 🧅 `tor-anonymizer` | HEAD requests to 16 **Tor Project, commercial VPN landing pages, and web-proxy sites** (check.torproject.org, ProtonVPN, NordVPN, Mullvad, ExpressVPN, kproxy.com, hide.me, croxyproxy.com, etc.). Tests the "anonymizers / proxy avoidance" URL-filter category on NGFW and SASE platforms. |
 | 👥 `shadow-it` | HEAD requests to **27 unsanctioned cloud applications** across five CASB app-control categories: personal file sharing (Dropbox, Box, MEGA, WeTransfer, iCloud), personal messaging (Discord, Telegram, WhatsApp Web), privacy mail (ProtonMail, Tutanota), paste/file hosting (Pastebin, Filebin, GoFile), and crypto/blockchain (Coinbase, Etherscan, Binance). |
 | 📞 `voip` | Two-phase **VoIP/WebRTC signaling simulation**. Phase 1: STUN Binding Requests (UDP/3478 + UDP/19302) to 15 public STUN servers used by Zoom, Google Meet, Teams, and open-source SIP stacks. Phase 2: SIP OPTIONS probes (UDP/5060) to 12 public SIP registrars — the standard SIP "ping" that triggers "SIP-signaling" app-ID signatures. No real calls placed. |

--- a/generator.py
+++ b/generator.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 """
-generator.py — Traffic Generator v3.9.0
+generator.py — Traffic Generator v3.9.1
 ========================================
 Simulates realistic network traffic across a wide range of protocols and
 behaviours: DNS, HTTP/HTTPS/HTTP3, FTP, SSH, NTP, BGP, ICMP, SNMP,
@@ -58,7 +58,7 @@ from rich import box
 from endpoints import *           # noqa: F401,F403  (large data file)
 
 # ── Globals ───────────────────────────────────────────────────────────────────
-VERSION = "3.9.0"
+VERSION = "3.9.1"
 
 
 class _DualWriter:
@@ -294,6 +294,7 @@ _SUITE_DESCRIPTIONS: list[tuple[str, str]] = [
     ("waf-attack",       "SQLi/XSS/LFI/SSRF/CMDi/XXE/SSTI payloads in query params and POST bodies → WAF inline"),
     ("data-exfil-http",  "POST synthetic PII/credentials to paste sites → DLP + CASB outbound inspection"),
     ("web-scanner",      "Nikto web vulnerability scan"),
+    ("iperf3",           "UDP 1 Mbps bandwidth test against public iperf3 servers (XS=1 S=2 M=3 L=4 XL=all 5) — validates egress port 5201 and bulk UDP flow detection"),
     ("all",              "Run every suite above in random order"),
 ]
 
@@ -2377,42 +2378,24 @@ def _iperf3_loopback(tests: list) -> None:
 
 def iperf3_bandwidth() -> None:
     """
-    iperf3 bandwidth test suite — validates egress port 5201/5202, bulk TCP/UDP
-    flow detection, QoS/rate-limiting, and bandwidth-anomaly rules.
-
-    Phase 1 — public iperf3 servers: attempts TCP, UDP, reverse, multi-stream,
-    and alternate-port tests against a random sample of well-known public servers.
-
-    Phase 2 — loopback fallback: if every public server is unreachable, starts a
-    local iperf3 server inside the container and runs the same variants against
-    127.0.0.1 so the suite always produces measurable output.
-
-    Custom flags: pass --iperf3-flags to replace the default test variants with
-    a single test using exactly those flags (e.g. --iperf3-flags "-t 10 -P 8 -u").
+    iperf3 bandwidth suite — sends a 1 Mbps UDP stream to public iperf3 servers.
+    XS=1 server, S=2, M=3, L=4, XL=all 5. Tests egress port 5201, UDP bulk flow
+    detection, and bandwidth-anomaly rules.
     """
-    custom = getattr(ARGS, "iperf3_flags", "").strip()
-    tests  = [("custom", custom)] if custom else list(_IPERF3_DEFAULT_TESTS)
-
-    n_servers = _size_to_limits(ARGS.size, 2, 3, 5, len(_IPERF3_SERVERS))
-    servers   = random.sample(_IPERF3_SERVERS, n_servers)
+    n_servers = _size_to_limits(ARGS.size, 2, 3, 4, len(_IPERF3_SERVERS), xs=1)
+    servers   = _IPERF3_SERVERS[:n_servers]
+    tests     = [("UDP 1M", "-u -b 1M -t 10")]
 
     ui_banner(
         "iperf3 Bandwidth",
-        f"size={ARGS.size} | {n_servers} server(s) | {len(tests)} test(s)"
-        + (" | custom flags" if custom else " | loopback fallback if unreachable"),
+        f"size={ARGS.size} | {n_servers} server(s) | UDP 1 Mbps",
     )
 
-    public_ok = False
     for host, port in servers:
         console.log(f"[cyan]→ {host}:{port}[/]")
-        if _iperf3_run_tests(host, port, tests) > 0:
-            public_ok = True
+        _iperf3_run_tests(host, port, tests)
 
-    if not public_ok:
-        console.log("[yellow]All public servers unreachable — running loopback fallback[/]")
-        _iperf3_loopback(tests)
-    else:
-        ui_ok("iperf3 bandwidth tests complete")
+    ui_ok("iperf3 bandwidth tests complete")
 
 def _nmap_classify(stdout: str) -> tuple[int, int, int]:
     """Parse nmap grepable output and return (open, closed, filtered) port counts."""
@@ -5031,6 +5014,7 @@ _SUITE_MAP: dict[str, list] = {
     "waf-attack":       [waf_attack],
     "data-exfil-http":  [data_exfil_http],
     "web-scanner":      [web_scanner],
+    "iperf3":           [iperf3_bandwidth],
 }
 
 

--- a/webui.py
+++ b/webui.py
@@ -2303,6 +2303,16 @@ docker run --pull=always -it jdibby/traffgen:latest --suite=dns --size=L</div>
       <div style="max-width:900px">
 
         <div class="a-section">
+          <div class="a-h">v3.9.1 &mdash; <span style="color:var(--muted);font-weight:400">May 2026</span></div>
+          <table class="st-table" style="margin-top:10px">
+            <tr><th style="width:80px">Type</th><th style="width:140px">Area</th><th>Description</th></tr>
+            <tr><td><span class="cl-feat">FEAT</span></td><td>Suites</td><td><strong>iperf3 suite restored</strong> — re-added <code>iperf3</code> to the suite map as a simplified UDP-only 1 Mbps test; t-shirt size controls server count (XS=1 S=2 M=3 L=4 XL=5 public servers); suite count 52 → 53</td></tr>
+            <tr><td><span class="cl-feat">FEAT</span></td><td>Diagnostics</td><td><strong>iperf3 diagnostics rework</strong> — bandwidth test tool now tests all 5 public servers every run with user-configurable bandwidth (default 10 M) and duration; per-server section headers, live interval table, and receiver summary card with loss % and jitter</td></tr>
+            <tr><td><span class="cl-feat">FEAT</span></td><td>Security</td><td><strong>Wider login card</strong> — sign-in card widened 380 → 460 px so the authorized-use disclaimer is easier to read; disclaimer font size increased and line-height loosened</td></tr>
+          </table>
+        </div>
+
+        <div class="a-section">
           <div class="a-h">v3.9.0 &mdash; <span style="color:var(--muted);font-weight:400">May 2026</span></div>
           <table class="st-table" style="margin-top:10px">
             <tr><th style="width:80px">Type</th><th style="width:140px">Area</th><th>Description</th></tr>

--- a/webui.py
+++ b/webui.py
@@ -1096,7 +1096,7 @@ def api_dns_lookup():
     return jsonify({"host": host, "results": results, "rtype": rtype, "mismatch": mismatch})
 
 
-# Public iperf3 servers (host, port) — tried in order, rotate on failure
+# Public iperf3 servers (host, port) — all are tested in order
 _IP3_SERVERS = [
     ("iperf.he.net",                5201),
     ("bouygues.iperf.fr",           5201),
@@ -1104,8 +1104,7 @@ _IP3_SERVERS = [
     ("iperf3.moji.fr",              5201),
     ("iperf.scottlinux.com",        5201),
 ]
-# T-shirt size → number of servers to try
-_IP3_SIZE_COUNT = {"XS": 1, "S": 2, "M": 3, "L": 4, "XL": 5}
+_IP3_BW_RE = __import__('re').compile(r'^\d+(\.\d+)?[KMG]?$')
 _IP3_INTERVAL_RE = __import__('re').compile(
     r'\[\s*\d+\]\s+([\d.]+)-([\d.]+)\s+sec\s+[\d.]+\s+\S+\s+'
     r'([\d.]+)\s+(\w+)bits/sec'
@@ -1123,24 +1122,23 @@ def api_iperf3():
             headers={"Cache-Control": "no-cache"},
         )
 
-    raw_size = request.args.get("size", "S").upper()
-    if raw_size not in _IP3_SIZE_COUNT:
-        return _sse_err("Invalid size — use XS, S, M, L, or XL")
-    count = _IP3_SIZE_COUNT[raw_size]
-
-    raw_duration = request.args.get("duration", "5")
-    if not raw_duration.isdigit() or not (1 <= int(raw_duration) <= 30):
-        return _sse_err("Invalid duration — must be 1–30 seconds")
+    raw_duration = request.args.get("duration", "10")
+    if not raw_duration.isdigit() or not (1 <= int(raw_duration) <= 60):
+        return _sse_err("Invalid duration — must be 1–60 seconds")
     safe_duration = str(int(raw_duration))
+
+    raw_bw = request.args.get("bandwidth", "10M").strip().upper()
+    if not _IP3_BW_RE.match(raw_bw):
+        return _sse_err("Invalid bandwidth — use e.g. 10M, 100K, 1G")
+    safe_bw = raw_bw  # regex-validated
 
     def _gen():
         import threading as _threading
-        servers = _IP3_SERVERS[:count]
         tested = 0
-        for idx, (host, port) in enumerate(servers):
-            yield f'data: {json.dumps({"type": "server", "host": host, "port": port, "index": idx, "total": len(servers)})}\n\n'
+        for idx, (host, port) in enumerate(_IP3_SERVERS):
+            yield f'data: {json.dumps({"type": "server", "host": host, "port": port, "index": idx, "total": len(_IP3_SERVERS)})}\n\n'
             cmd = ["iperf3", "-c", host, "-p", str(port),
-                   "-t", safe_duration, "-u", "-b", "1M", "--forceflush"]
+                   "-t", safe_duration, "-u", "-b", safe_bw, "--forceflush"]
             try:
                 proc = subprocess.Popen(
                     cmd,
@@ -1347,7 +1345,7 @@ def _login_page(error: str = "") -> str:
 <style>
 *{{box-sizing:border-box;margin:0;padding:0}}
 body{{background:#0d1117;color:#c9d1d9;font-family:system-ui,sans-serif;display:flex;align-items:center;justify-content:center;min-height:100vh}}
-.card{{background:#161b22;border:1px solid #30363d;border-radius:10px;padding:36px 32px;width:380px}}
+.card{{background:#161b22;border:1px solid #30363d;border-radius:10px;padding:36px 36px;width:460px;max-width:96vw}}
 .brand{{font-size:13px;color:#8b949e;text-align:center;margin-bottom:20px;letter-spacing:.02em}}
 h1{{font-size:18px;font-weight:600;margin-bottom:22px;color:#e6edf3}}
 label{{font-size:12px;color:#8b949e;display:block;margin-bottom:5px;text-transform:uppercase;letter-spacing:.04em}}
@@ -1358,8 +1356,8 @@ button:hover{{background:#2ea043}}
 .err{{color:#f85149;font-size:13px;margin-bottom:14px;padding:8px 10px;background:rgba(248,81,73,.1);border-radius:5px}}
 .disc{{margin-top:22px;padding:14px;background:rgba(210,153,34,.08);border:1px solid rgba(210,153,34,.35);border-radius:6px}}
 .disc-hdr{{display:flex;align-items:center;gap:7px;font-size:12px;font-weight:700;color:#d97706;text-transform:uppercase;letter-spacing:.05em;margin-bottom:8px}}
-.disc ul{{padding-left:16px;color:#8b949e;font-size:12px;line-height:1.65}}
-.disc li{{margin-bottom:4px}}
+.disc ul{{padding-left:16px;color:#8b949e;font-size:13px;line-height:1.7}}
+.disc li{{margin-bottom:5px}}
 .disc strong{{color:#c9d1d9}}
 </style></head>
 <body><div class="card">
@@ -2160,19 +2158,19 @@ body.ro-mode .ro-ctrl{opacity:.32;cursor:not-allowed}
         <div id="dns-results"><div class="tr-status">Enter a hostname and click Lookup.</div></div>
       </div>
       <div class="diag-tool">
-        <div class="diag-tool-hdr">&#128246; iperf3 Bandwidth Test <span style="font-size:11px;font-weight:400;color:var(--muted);text-transform:none;letter-spacing:0">UDP · 1 Mbps · public servers</span></div>
+        <div class="diag-tool-hdr">&#128246; iperf3 Bandwidth Test <span style="font-size:11px;font-weight:400;color:var(--muted);text-transform:none;letter-spacing:0">UDP · all public servers</span></div>
         <div class="diag-input-row">
-          <select id="ip3-size" class="diag-input" style="flex:0 0 auto;width:auto;padding-right:18px" title="Number of servers to test">
-            <option value="XS">XS — 1 server</option>
-            <option value="S" selected>S — 2 servers</option>
-            <option value="M">M — 3 servers</option>
-            <option value="L">L — 4 servers</option>
-            <option value="XL">XL — 5 servers</option>
-          </select>
-          <input id="ip3-duration" class="diag-input" type="number" value="5" min="1" max="30" style="flex:0 0 72px;min-width:60px" title="Duration per server (s)" placeholder="5s">
-          <span style="font-size:12px;color:var(--muted);white-space:nowrap;align-self:center">sec / server</span>
-          <button id="ip3-btn" class="diag-btn" onclick="runIperf3()">Run</button>
-          <button id="ip3-stop" class="diag-btn cancel" onclick="stopIperf3()" style="display:none">Stop</button>
+          <div style="display:flex;align-items:center;gap:4px">
+            <label style="font-size:12px;color:var(--muted);white-space:nowrap">Bandwidth</label>
+            <input id="ip3-bw" class="diag-input" type="text" value="10M" style="width:72px" title="UDP target bandwidth (e.g. 1M, 10M, 100M)" placeholder="10M" spellcheck="false">
+          </div>
+          <div style="display:flex;align-items:center;gap:4px">
+            <label style="font-size:12px;color:var(--muted);white-space:nowrap">Duration</label>
+            <input id="ip3-duration" class="diag-input" type="number" value="10" min="1" max="60" style="width:64px" title="Duration per server (seconds)">
+            <span style="font-size:12px;color:var(--muted)">s</span>
+          </div>
+          <button id="ip3-btn" class="diag-btn" onclick="runIperf3()">&#9654; Run All Servers</button>
+          <button id="ip3-stop" class="diag-btn cancel" onclick="stopIperf3()" style="display:none">&#9209; Stop</button>
         </div>
         <div id="ip3-results" style="display:none">
           <div id="ip3-status" class="tr-status"></div>
@@ -2230,7 +2228,7 @@ body.ro-mode .ro-ctrl{opacity:.32;cursor:not-allowed}
         <div>
           <div class="a-title">traffgen</div>
           <div class="a-ver">v<span id="about-ver">&#8212;</span> &middot; Multi-Protocol Network Traffic Generator</div>
-          <div class="a-sub">Simulates realistic network traffic across 52 test suites &#8212; DNS, HTTP/S, BGP, SSH, VoIP/UCaaS, C2 beacons, DLP, IDS/WAF triggers, lateral movement, TLS inspection, Metasploit vuln scanners, encoded payload delivery, and more.<br>Purpose-built to stress-test firewalls, IDS/IPS, URL filters, DLP engines, CASB/SASE/SSE platforms, and SIEM pipelines.</div>
+          <div class="a-sub">Simulates realistic network traffic across 53 test suites &#8212; DNS, HTTP/S, BGP, SSH, VoIP/UCaaS, C2 beacons, DLP, IDS/WAF triggers, lateral movement, TLS inspection, Metasploit vuln scanners, encoded payload delivery, and more.<br>Purpose-built to stress-test firewalls, IDS/IPS, URL filters, DLP engines, CASB/SASE/SSE platforms, and SIEM pipelines.</div>
         </div>
       </div>
       <div class="a-section">
@@ -2274,7 +2272,7 @@ docker run --pull=always -it jdibby/traffgen:latest --suite=dns --size=L</div>
           <tr><td>IDS / IPS / WAF</td><td style="color:var(--text)">ids-trigger &middot; waf-attack &middot; log4shell &middot; nmap &middot; msf-webapp &middot; msf-enterprise &middot; msf-appliance &middot; msf-cisa-kev &middot; msf-middleware &middot; msf-recon &middot; web-scanner</td></tr>
           <tr><td>VoIP / UCaaS</td><td style="color:var(--text)">voip &middot; ucaas</td></tr>
           <tr><td>SASE / SSE / CASB</td><td style="color:var(--text)">shadow-it &middot; tor-anonymizer &middot; tls-inspection &middot; lateral-movement</td></tr>
-          <tr><td>Security Tools</td><td style="color:var(--text)">snmp &middot; post-quantum &middot; ai-browse</td></tr>
+          <tr><td>Security Tools</td><td style="color:var(--text)">snmp &middot; post-quantum &middot; ai-browse &middot; iperf3</td></tr>
           <tr><td>all</td><td style="color:var(--text)">Shuffled rotation of every suite above</td></tr>
         </table>
       </div>
@@ -3947,15 +3945,15 @@ function _renderIpResult(d){
     +'</div>';
 }
 function runIperf3(){
-  const size=$('ip3-size').value;
-  const dur=($('ip3-duration').value||'5').trim();
+  const bw=($('ip3-bw').value||'10M').trim().toUpperCase();
+  const dur=($('ip3-duration').value||'10').trim();
   stopIperf3();
   $('ip3-results').style.display='';
   $('ip3-table').innerHTML='';
   $('ip3-summary').innerHTML='';
   $('ip3-status').textContent='Starting…';
   $('ip3-btn').disabled=true;$('ip3-stop').style.display='';
-  const url='/api/iperf3?size='+encodeURIComponent(size)+'&duration='+encodeURIComponent(dur);
+  const url='/api/iperf3?bandwidth='+encodeURIComponent(bw)+'&duration='+encodeURIComponent(dur);
   _ipSrc=new EventSource(url);
   _ipSrc.onmessage=e=>{
     const d=JSON.parse(e.data);


### PR DESCRIPTION
## Summary

**iperf3 test suite (generator.py)**
- Re-added `iperf3` to `_SUITE_MAP` and `_SUITE_DESCRIPTIONS` — suite count 52 → 53
- Always UDP 1 Mbps (`-u -b 1M -t 10`) — no custom flags, no loopback fallback
- T-shirt size controls how many public servers are tested: XS=1, S=2, M=3, L=4, XL=all 5

**iperf3 diagnostics tool (webui.py)**
- Removed the size dropdown — now tests **all 5 public servers** every run
- Added **Bandwidth** input (default `10M`) and **Duration** input (default `10s`) per server
- Users can set their own target rate and duration; servers are tested one at a time with live interval table + summary card per server

**Login card (webui.py)**
- Widened from 380px → 460px so the authorized-use disclaimer is easier to read
- Disclaimer list font bumped 12px → 13px with looser line-height

**Docs / version**
- Version 3.9.0 → 3.9.1
- Suite count 52 → 53 in README, docs/suites.md, and webui.py About tab
- `iperf3` entry added to docs/suites.md

## Test plan
- [ ] `--suite=iperf3 --size=XS` — 1 server tested, UDP 1M, 10s run
- [ ] `--suite=iperf3 --size=XL` — all 5 servers tested
- [ ] Diagnostics → iperf3 → set 50M / 5s → Run — all 5 servers cycle through with live interval rows
- [ ] One server unreachable → amber "Skipped" message appears, continues to next
- [ ] Login page — card is noticeably wider, disclaimer text readable on one column

https://claude.ai/code/session_01QiHkJ7DeFEB7bsfFW93bXW

---
_Generated by [Claude Code](https://claude.ai/code/session_01QiHkJ7DeFEB7bsfFW93bXW)_