### PR TITLE
chore: serve preview files via /preview/ route

### DIFF
--- a/webui.py
+++ b/webui.py
@@ -24,7 +24,7 @@ import threading
 
 logging.getLogger("werkzeug").setLevel(logging.ERROR)
 
-from flask import Flask, Response, jsonify, redirect, request, session, url_for  # noqa: E402
+from flask import Flask, Response, jsonify, redirect, request, send_from_directory, session, url_for  # noqa: E402
 
 # ── Constants ──────────────────────────────────────────────────────────────────
 _STATE_FILE  = "/tmp/traffgen_state.json"
@@ -716,6 +716,13 @@ def change_password():
             session["must_change"] = False
             return redirect(url_for("index"))
     return Response(_change_pw_page(error), mimetype="text/html")
+
+
+_PREVIEW_DIR = os.path.join(os.path.dirname(__file__), "preview")
+
+@app.route("/preview/<path:filename>")
+def serve_preview(filename):
+    return send_from_directory(_PREVIEW_DIR, filename)
 
 
 @app.route("/api/state")


### PR DESCRIPTION
Adds a Flask `/preview/<filename>` route so the Traffic Map design mockups are accessible directly from the webui without needing filesystem access.

Open in browser:
- `https://<host>:7777/preview/option1-soc-dark.html`
- `https://<host>:7777/preview/option2-globe.html`
- `https://<host>:7777/preview/option3-split.html`
- `https://<host>:7777/preview/option4-neon.html`

https://claude.ai/code/session_01QiHkJ7DeFEB7bsfFW93bXW

---
_Generated by [Claude Code](https://claude.ai/code/session_01QiHkJ7DeFEB7bsfFW93bXW)_