### PR TITLE
fix(csp): allow Leaflet CDNs, CartoDB tiles, and ip-api in CSP header

### DIFF
--- a/webui.py
+++ b/webui.py
@@ -545,9 +545,10 @@ _SEC_HEADERS = {
     "Cache-Control":             "no-store",
     "Content-Security-Policy": (
         "default-src 'none'; "
-        "style-src 'unsafe-inline'; "
-        "script-src 'unsafe-inline'; "
-        "connect-src 'self'"
+        "style-src 'unsafe-inline' https://cdn.jsdelivr.net https://unpkg.com; "
+        "script-src 'unsafe-inline' https://cdn.jsdelivr.net https://unpkg.com; "
+        "img-src 'self' data: https://*.basemaps.cartocdn.com; "
+        "connect-src 'self' https://ip-api.com"
     ),
     "Strict-Transport-Security": "max-age=31536000",
     "Permissions-Policy":        "geolocation=(), microphone=(), camera=()",


### PR DESCRIPTION
## Summary
The Traffic Map was completely blocked by the app's own Content Security Policy. Chrome devtools showed all four resources being rejected:
- Leaflet CSS from unpkg.com → `style-src` violation
- Leaflet JS from unpkg.com → `script-src` violation  
- CartoDB tile images → `img-src` violation (default-src 'none')
- ip-api.com geo lookup → `connect-src 'self'` violation

## Changes
Added the minimum necessary CDN/domain allowances to the CSP:
- `script-src`: `cdn.jsdelivr.net`, `unpkg.com`
- `style-src`: `cdn.jsdelivr.net`, `unpkg.com`
- `img-src`: `*.basemaps.cartocdn.com` (map tiles) + `data:` (Leaflet marker icons)
- `connect-src`: `ip-api.com` (source geolocation, non-critical)

All other restrictions remain unchanged.

https://claude.ai/code/session_01QiHkJ7DeFEB7bsfFW93bXW

---
_Generated by [Claude Code](https://claude.ai/code/session_01QiHkJ7DeFEB7bsfFW93bXW)_