### PR TITLE
fix: add cdn.jsdelivr.net to connect-src for Leaflet source map

### DIFF
--- a/webui.py
+++ b/webui.py
@@ -548,7 +548,7 @@ _SEC_HEADERS = {
         "style-src 'unsafe-inline' https://cdn.jsdelivr.net https://unpkg.com; "
         "script-src 'unsafe-inline' https://cdn.jsdelivr.net https://unpkg.com; "
         "img-src 'self' data: https://*.basemaps.cartocdn.com; "
-        "connect-src 'self' https://ip-api.com"
+        "connect-src 'self' https://cdn.jsdelivr.net https://unpkg.com https://ip-api.com"
     ),
     "Strict-Transport-Security": "max-age=31536000",
     "Permissions-Policy":        "geolocation=(), microphone=(), camera=()",


### PR DESCRIPTION
$(cat <<'EOF'
## Summary
- Browser fetches `leaflet.js.map` via `connect-src` which wasn't included in the CSP
- Adds `https://cdn.jsdelivr.net` and `https://unpkg.com` to `connect-src` directive

## Test plan
- [ ] After deploy, open Traffic Map tab — no CSP errors in console
- [ ] Map tiles and arcs render correctly

https://claude.ai/code/session_01QiHkJ7DeFEB7bsfFW93bXW
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QiHkJ7DeFEB7bsfFW93bXW)_