### PR TITLE
fix(http3): add 10 s per-probe timeout to prevent QUIC handshake stalls

### DIFF
--- a/generator.py
+++ b/generator.py
@@ -3087,12 +3087,16 @@ def http3_random() -> None:
             verify_mode=_ssl.CERT_NONE,
             server_name=host,
         )
-        try:
+
+        async def _do() -> str | None:
             async with quic_connect(
                 host, port, configuration=cfg,
                 create_protocol=_H3Client,
             ) as proto:
-                status = await proto.head(url, ua)
+                return await proto.head(url, ua)
+
+        try:
+            status = await asyncio.wait_for(_do(), timeout=10.0)
             code = status or "000"
             console.log(f"HTTP3 ({idx}/{n}) {url}  → [{_status_style(code)}]{code}[/]")
             _stats.record(code)


### PR DESCRIPTION
## Problem

`http3` gets stuck — each blocked endpoint can hang for ~60 s before giving up. The inner `asyncio.wait_for(self._done.wait(), timeout=5.0)` in `head()` only covers waiting for the HTTP response headers, but the QUIC handshake itself (`quic_connect()`) has no timeout. When a firewall silently drops UDP/443, the aioquic stack retries until the OS's socket timeout fires (~60 s).

## Fix

Wrap the entire `quic_connect()` + `head()` call chain in `asyncio.wait_for(..., timeout=10.0)`. Each probe now fails fast with a `timeout` log line instead of hanging a minute per endpoint.

## Test plan

- [ ] Run `--suite=http3` on a network where QUIC is blocked — each endpoint should show `→ timeout` within ~10 s instead of ~60 s
- [ ] Run `--suite=http3` on a permissive network — successful probes still complete normally

https://claude.ai/code/session_01QiHkJ7DeFEB7bsfFW93bXW

---
_Generated by [Claude Code](https://claude.ai/code/session_01QiHkJ7DeFEB7bsfFW93bXW)_