### PR TITLE
fix: modal renders under Traffic Map — isolate Leaflet stacking context

### DIFF
--- a/webui.py
+++ b/webui.py
@@ -1660,7 +1660,7 @@ select.diag-input{appearance:none;-webkit-appearance:none;background-color:var(-
 #tab-trafficmap.panel.active{flex-direction:column}
 .tmap-main-row{display:flex;flex-direction:row;flex:1;min-height:0;overflow:hidden}
 .tmap-left-col{display:flex;flex-direction:column;flex:1;min-width:0}
-#tmap-container{flex:1;display:flex;flex-direction:column;min-width:0;min-height:0;position:relative;background:#04060a}
+#tmap-container{flex:1;display:flex;flex-direction:column;min-width:0;min-height:0;position:relative;background:#04060a;isolation:isolate}
 #tmap{flex:1;min-height:200px}
 .tmap-strip{display:none}.tmap-legend{display:none}.tmap-right{display:none}
 .tmap-n{font-size:20px;font-weight:800;line-height:1;letter-spacing:-.5px;text-align:center}


### PR DESCRIPTION
## Problem

When launching a test from the Tests tab while the Traffic Map tab was previously visited, the run modal appeared underneath the map elements.

## Root Cause

Leaflet creates map panes with z-indexes up to 700 (popup pane: 700, tooltip pane: 650, marker pane: 600). Because `#tmap-container` had no stacking context of its own (`position: relative` without a z-index), Leaflet's pane z-indexes were computed in the **page-level** stacking context. The modal overlay uses `z-index: 400` — below Leaflet's marker/tooltip/popup layers.

## Fix

Add `isolation: isolate` to `#tmap-container`. This creates a stacking context for the map, scoping all Leaflet z-indexes inside it. The modal at `z-index: 400` in the root context now correctly appears above the entire map container. The floating legend and stats overlays (`z-index: 1000`) still render above Leaflet's layers within the isolated context.

https://claude.ai/code/session_01QiHkJ7DeFEB7bsfFW93bXW

---
_Generated by [Claude Code](https://claude.ai/code/session_01QiHkJ7DeFEB7bsfFW93bXW)_