### PR TITLE
fix(lateral-movement): tune nmap ping sweep to reduce false positives

### DIFF
--- a/generator.py
+++ b/generator.py
@@ -4774,7 +4774,8 @@ def lateral_movement_sim() -> None:
         live_hosts: list[str] = []
         try:
             sweep = subprocess.run(
-                ["nmap", "-sn", "--send-ip", "-T4",
+                ["nmap", "-sn", "-PE", "--send-ip", "-T5",
+                 "--min-parallelism", "100", "--min-rate", "1000",
                  "--max-retries", "1", "--host-timeout", "10s",
                  "-oG", "-", subnet],
                 capture_output=True, text=True, timeout=240,


### PR DESCRIPTION
## Summary

Phase 1 of `lateral_movement_sim()` was producing false positives on /32 microsegmented networks. This narrows host discovery to ICMP echo only and bumps the timing template.

**Changes to the nmap call in `generator.py:4776-4781`:**

| | Before | After |
|---|---|---|
| Discovery probes | nmap default mix | `-PE` (ICMP echo only) |
| Timing template | `-T4` | `-T5` |
| Parallelism | (nmap default) | `--min-parallelism 100` |
| Min rate | (nmap default) | `--min-rate 1000` |

**Preserved on purpose:**
- `--send-ip` — required on /32 microseg setups (no ARP fallback available).
- `--max-retries 1` / `--host-timeout 10s` / 240s subprocess timeout — existing reliability rails that prevent single-host hangs and runaway scans.
- `-oG -` — downstream parser depends on grepable output.

## Test plan

- [ ] Run `traffgen --suite lateral-movement` on a /32 microsegmented host and confirm the host count drops to actual ICMP-responsive devices.
- [ ] Run on a typical /24 LAN and confirm sweep still completes within the 240s subprocess timeout.
- [ ] Confirm the per-host port-scan phase (Phase 2) is unaffected.

https://claude.ai/code/session_01WY6BVw5wAdiq4kYz5LQ3kf

---
_Generated by [Claude Code](https://claude.ai/code/session_01WY6BVw5wAdiq4kYz5LQ3kf)_