### PR TITLE
fix(lateral-movement): exclude scanner's own IP from ping sweep

### DIFF
--- a/generator.py
+++ b/generator.py
@@ -4777,6 +4777,7 @@ def lateral_movement_sim() -> None:
                 ["nmap", "-sn", "-PE", "--send-ip", "-T5",
                  "--min-parallelism", "100", "--min-rate", "1000",
                  "--max-retries", "1", "--host-timeout", "10s",
+                 "--exclude", gw_ip,
                  "-oG", "-", subnet],
                 capture_output=True, text=True, timeout=240,
             )


### PR DESCRIPTION
## Summary

The host running the container was showing up in its own ping-sweep results, polluting the live-host list and the Phase 2 port-scan targets.

Observed during validation:
```
root@CATO-SITE1-VM-1:~# nmap -sn -PE -T5 --min-parallelism 100 --min-rate 1000 192.168.10.0/24
...
Nmap scan report for CATO-SITE1-VM-1 (192.168.10.12)   ← scanner itself
```

## Fix

Add `--exclude gw_ip` to the Phase 1 nmap call. `gw_ip` is the host's address on the subnet being scanned and is already available from `_detect_host_lans()`.

`--exclude` skips the host entirely during discovery — cleaner than post-filtering parsed output and saves a probe.

## Test plan

- [ ] Re-run `traffgen --suite lateral-movement` from the same host that produced the bug report and confirm the scanner's own IP is absent from both the Phase 1 live-host list and the Phase 2 port-scan targets.
- [ ] Re-run on a host with multiple LANs and confirm each scan correctly excludes only the IP relevant to its subnet.

https://claude.ai/code/session_01WY6BVw5wAdiq4kYz5LQ3kf

---
_Generated by [Claude Code](https://claude.ai/code/session_01WY6BVw5wAdiq4kYz5LQ3kf)_