### PR TITLE
fix(trafficmap): emit log marker on block() so Traffic Map detects blocks

### DIFF
--- a/generator.py
+++ b/generator.py
@@ -422,6 +422,15 @@ class SuiteStats:
             self.codes[bucket] = self.codes.get(bucket, 0) + 1
             if target and len(self.probes) < _PROBE_DETAIL_MAX:
                 self.probes.append({"t": target, "o": "blocked", "c": bucket})
+        # Emit a marker into the SSE log stream so the Traffic Map can detect
+        # the block — many block() call sites are otherwise silent (HTTP 200
+        # captive portals, port-scan results, TLS-inspection intercepts) and
+        # the regex in _tmapOutcome has nothing to match in the surrounding
+        # log lines.  The literal word "blocked" is the matched keyword.
+        try:
+            _web_log(f"blocked {target}".strip(), level="warn")
+        except Exception:
+            pass
 
     def drop(self, exit_code: int = 28, target: str = "") -> None:
         """Record a silent drop (timeout, no route, DNS sinkhole)."""


### PR DESCRIPTION
## Summary

Traffic Map's "Blocked" counter (and the BLOCKED badges in the Live Hit Feed) was always 0 even though `_stats.block()` was firing correctly server-side and the Security tab showed accurate counts.

## Root cause

`webui.py:_tmapOutcome()` detects blocks purely by regex-matching incoming log lines for keywords like `blocked`, `refused`, `RST`, `403`, etc. Most `_stats.block()` call sites in `generator.py` either log nothing at all or log lines that don't match the regex — so those blocks were invisible to the Traffic Map.

Examples of previously-invisible blocks:
- `http_download_zip` / `malware-samples` (captive portal detection): logs `↳ HTTP 200` then calls `block()` silently — Traffic Map saw `200` and marked it **allowed**.
- `nmap` port-scan results (L2458, L4845): completely silent.
- `tls-inspection` `INTERCEPTED` outcome (L4170): no keyword in surrounding logs.

## Fix

Emit one structured `_web_log("blocked <target>", level="warn")` from inside `_stats.block()`, **after** releasing the lock so I/O isn't held under it. The literal word `blocked` matches the existing `_tmapOutcome` regex; the optional `target` lets the Traffic Map either extract a host directly or fall back to its existing `_tmapLastHost` correlation path.

All exceptions are swallowed — the authoritative counter (`self.blocked += 1`) is never affected by logging failures.

## What this does NOT change

- The Security tab's numbers (already correct).
- Drop counters (out of scope; user reported only blocks; the Traffic Map doesn't currently have a Dropped tile).
- The trafficmap regex (unchanged — it already matches the word `blocked`).

## Test plan

- [ ] Run `traffgen --suite all --size S --loop` and confirm the Traffic Map's **Blocked** counter advances within the first few suites that fire `block()` (most easily: `nmap`, `tls-inspection`, `malware-samples`).
- [ ] Confirm the **Live Hit Feed** shows BLOCKED badges on suites that previously showed only "allowed" / no badge.
- [ ] Cross-check that the Traffic Map "Blocked" total stays consistent with the Security tab's blocked aggregate over the same window.

https://claude.ai/code/session_01WY6BVw5wAdiq4kYz5LQ3kf

---
_Generated by [Claude Code](https://claude.ai/code/session_01WY6BVw5wAdiq4kYz5LQ3kf)_