### PR TITLE
fix(webui): _onTestSearch / setTestsCat called undefined renderState

### DIFF
--- a/webui.py
+++ b/webui.py
@@ -3316,13 +3316,13 @@ function _onTestSearch(q){
   _testSearch=q;
   const clr=$('test-search-clear');if(clr)clr.style.display=q?'':'none';
   const inp=$('test-search');if(inp)inp.style.borderColor=q?'var(--green)':'';
-  if(_lastState)renderState(_lastState);
+  if(_lastState)apply(_lastState);
 }
 function setTestsCat(el,cat){
   _testsCat=cat;
   document.querySelectorAll('.nav-sub-item').forEach(b=>b.classList.remove('active'));
   el.classList.add('active');
-  if(_lastState)renderState(_lastState);
+  if(_lastState)apply(_lastState);
 }
 function showTab(btn){
   document.querySelectorAll('.panel').forEach(p=>p.classList.remove('active'));


### PR DESCRIPTION
## Summary

Two Tests-tab event handlers call a function that no longer exists.

```js
function _onTestSearch(q){
  ...
  if(_lastState)renderState(_lastState);   // ← renderState is not defined
}
function setTestsCat(el,cat){
  ...
  if(_lastState)renderState(_lastState);   // ← same
}
```

The dashboard's main state renderer was renamed `renderState` → `apply` somewhere in the recent refactor (`apply()` is defined at `webui.py:3373`); these two call sites were never updated.

Result:
- Every keystroke in the suite search box throws `Uncaught ReferenceError: renderState is not defined`.
- Clicking any Tests sub-category throws the same error.
- The buttons reported as unresponsive (**Apply & Restart**, **Run This Test**) appear to fail "after the first use" — this is consistent with the cascading event-handler breakage that follows a thrown ReferenceError in a high-frequency event handler.

## Fix

Rename both call sites to `apply(_lastState)` — the renderer that's actually defined and already wired to every other state-driven UI update.

## Test plan

- [ ] Reload the dashboard, open DevTools console, type in the **Tests &rarr; Search** input. No ReferenceError should appear.
- [ ] Click each sub-category under the Tests nav-item. No error.
- [ ] Open Settings &rarr; **Apply & Restart** twice in a row. Both should work.
- [ ] Open any per-test modal &rarr; **Run This Test**, then do it again on another test. Both should work.

https://claude.ai/code/session_01WY6BVw5wAdiq4kYz5LQ3kf

---
_Generated by [Claude Code](https://claude.ai/code/session_01WY6BVw5wAdiq4kYz5LQ3kf)_