### PR TITLE
fix(trafficmap): show 403/Forbidden hits in feed + readable light mode

### DIFF
--- a/webui.py
+++ b/webui.py
@@ -1904,6 +1904,10 @@ html.light .tmap-right-col{background:#f0f3f7;border-left-color:#d0d7de}
 html.light .tmap-c-section{border-bottom-color:#d0d7de}
 html.light .tmap-c-title{color:#636e7b;background:#f0f3f7}
 html.light .tmap-feed-title{color:#636e7b;background:#f0f3f7;border-bottom-color:#d0d7de}
+html.light .tmap-feed-item{border-bottom-color:#e6eaf0}
+html.light .tmap-f-host{color:#1f2937}
+html.light .tmap-f-loc{color:#4a5568}
+html.light .tmap-f-time{color:#6b7280}
 html.light .tmap-l{color:#636e7b}
 html.light .tmap-leg-item{color:#4a5568}
 html.light .tmap-src-city{color:#b7791f;text-shadow:none}
@@ -5107,8 +5111,10 @@ function _tmapExtractHost(msg){
   // 0. DNS dig line — extract the @server_ip (the actual connection target)
   let m=msg.match(/\bdig\b[^@]*@(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})/);
   if(m)return m[1];
-  // 1. Full URL — most reliable
-  m=msg.match(/https?:\/\/([^/\s>"']+)/);
+  // 1. Full URL — restrict captured host to valid hostname characters so
+  //    trailing punctuation in log lines (e.g. "https://site.com: 403")
+  //    doesn't get included in the captured hostname.
+  m=msg.match(/https?:\/\/([a-z0-9._-]+)/i);
   if(m)return m[1].toLowerCase().replace(/^www2?\./,'');
   // 2. Arrow notation: "→ host[:port]"
   m=msg.match(/→\s*([a-z0-9][a-z0-9._-]+\.[a-z]{2,})/i);


### PR DESCRIPTION
## Summary

Two Traffic Map fixes from a live pornography-suite run that turned up only ~2 feed entries despite ~50 forbidden URLs and unreadable text in light mode.

### 1. 403/Forbidden hits never reached the feed

`scrape_single_link()` logs HTTP errors like:
```
WARN  HTTP error https://theporndude.com: 403 Client Error: Forbidden for url:
```

`_tmapOutcome()` matched the line as `blocked` (regex hits both `403` and `Forbidden`) — but `_tmapExtractHost()` used `/https?:\/\/([^/\s>"']+)/` which captured everything up to the next whitespace, including the trailing `:` punctuation after the URL. The extracted host became `theporndude.com:` (with a stray colon), the geo lookup silently failed on the malformed name, and no arc or feed entry was produced.

**Fix:** restrict Pattern 1's capture group to valid hostname characters (`[a-z0-9._-]+`) so trailing punctuation is left out. Patterns 2-5 already use strict character classes; only Pattern 1 was broad.

### 2. Light mode unreadable on the feed

`.tmap-f-host` is hardcoded to `#e2e8f0` (near-white) and `.tmap-f-time` to `#2d3748` — both fine on the dark theme but unreadable on `html.light`. Added overrides matching the existing light-mode pattern (`html.light .tmap-feed-title{...}` at line 1906):

- `.tmap-f-host` → `#1f2937` (slate-800, readable on light backgrounds)
- `.tmap-f-loc` → `#4a5568`
- `.tmap-f-time` → `#6b7280`
- `.tmap-feed-item` separator → `#e6eaf0`

## Test plan

- [ ] Run `traffgen --suite pornography --size M` and confirm the Live Hit Feed populates with one entry per 403 Forbidden URL (not just 2).
- [ ] Toggle to light mode and confirm host/location/time text is legible.
- [ ] Re-run any HTTP-heavy suite (e.g. `http`, `web-crawl`) and verify hosts still extract correctly — no regression.

https://claude.ai/code/session_01WY6BVw5wAdiq4kYz5LQ3kf

---
_Generated by [Claude Code](https://claude.ai/code/session_01WY6BVw5wAdiq4kYz5LQ3kf)_