### PR TITLE
feat(trafficmap): full suite coverage — fallback hosts for all 55 suites

### DIFF
--- a/webui.py
+++ b/webui.py
@@ -5242,6 +5242,43 @@ const _tmapSuiteHosts={
   'phishing-domains':['phishtank.org','openphish.com','safe.dnsfilter.com','urlhaus-api.abuse.ch'],
   'tls-inspection':['expired.badssl.com','wrong.host.badssl.com','self-signed.badssl.com','untrusted-root.badssl.com'],
   'lateral-movement':['8.8.8.8','1.1.1.1','scanme.nmap.org','testmyids.com'],
+  // ── HTTP/web family — most log URLs inline; fallbacks for empty windows ────
+  'http':['link.testfile.org','wordpress.org','example.com','httpforever.com'],
+  'https':['google.com','cloudflare.com','example.com','www.wikipedia.org'],
+  'http3':['cloudflare-quic.com','www.cloudflare.com','www.google.com','quic.aiortc.org'],
+  'web-crawl':['data.commoncrawl.org','en.wikipedia.org','news.ycombinator.com','reddit.com'],
+  'ftp':['ftp.gnu.org','ftp.fau.de','speedtest.tele2.net'],
+  'ssh':['github.com','gitlab.com','bitbucket.org'],
+  'post-quantum':['pq.cloudflareresearch.com','www.cloudflare.com','www.google.com'],
+  'url-latency':['google.com','cloudflare.com','amazon.com','microsoft.com','apple.com'],
+  's3':['s3.amazonaws.com','s3.us-east-1.amazonaws.com','s3.us-west-2.amazonaws.com'],
+  'iperf3':['iperf3.serverius.net','iperf.he.net','speedtest.serverius.net','bouygues.iperf.fr','iperf.it-north.net'],
+  // ── DNS family ────────────────────────────────────────────────────────────
+  'doh':['cloudflare-dns.com','dns.google','doh.opendns.com','dns.quad9.net','dns.nextdns.io','dns.adguard-dns.com'],
+  'dot':['1.1.1.1','8.8.8.8','9.9.9.9','208.67.222.222','94.140.14.14'],
+  'dns-exfil':['testmyids.com','scanme.nmap.org','example.com','example.org','info.cern.ch'],
+  // ── Voice / video ─────────────────────────────────────────────────────────
+  'voip':['stun.l.google.com','stun.cloudflare.com','stun.zoom.us','sip.linphone.org','sip.voip.ms','sip.callcentric.com'],
+  'ucaas':['zoom.us','teams.microsoft.com','webex.com','meet.google.com','slack.com','ringcentral.com','8x8.com'],
+  // ── DLP / data-exfil ──────────────────────────────────────────────────────
+  'dlp':['dlptest.com'],
+  'data-exfil-http':['pastebin.com','hastebin.com','paste2.org','transfer.sh','filebin.net','api.paste.fo'],
+  // ── AI / LLM ──────────────────────────────────────────────────────────────
+  'ai-browse':['openai.com','chat.openai.com','claude.ai','gemini.google.com','copilot.microsoft.com','perplexity.ai','character.ai'],
+  'llm-dlp':['api.openai.com','api.anthropic.com','generativelanguage.googleapis.com','api.cohere.com','api.together.ai','api.mistral.ai'],
+  // ── Threat / malware ──────────────────────────────────────────────────────
+  'av-test':['secure.eicar.org','2016.eicar.org','www.eicar.org','wildfire.paloaltonetworks.com'],
+  'malware-samples':['testmyids.com','www.testmyids.com','wildfire.paloaltonetworks.com'],
+  'c2-beacon':['www.testmyids.com','httpbin.org','testmyids.com'],
+  'c2-useragents':['testmyids.com','www.testmyids.com'],
+  'waf-attack':['juice-shop.herokuapp.com','www.testmyids.com','hackazon.webscantest.com','testhtml5.vulnweb.com'],
+  'nmap':['scanme.nmap.org'],
+  // ── Categories: trackers, anonymizers, shadow IT, content filters ─────────
+  'ad-tracker':['doubleclick.net','googletagmanager.com','google-analytics.com','adsystem.amazon.com','scorecardresearch.com'],
+  'tor-anonymizer':['check.torproject.org','www.torproject.org','protonvpn.com','nordvpn.com','mullvad.net','www.expressvpn.com'],
+  'shadow-it':['dropbox.com','box.com','mega.nz','wetransfer.com','transfer.sh','discord.com','web.telegram.org','www.coinbase.com','www.binance.com'],
+  'pornography':['pornhub.com','xvideos.com','xhamster.com','youporn.com','redtube.com'],
+  'squatting':['google.com','facebook.com','amazon.com','apple.com','microsoft.com'],
 };
 function _tmapIsPrivateIP(h){return/^(10\.|172\.(1[6-9]|2\d|3[01])\.|192\.168\.|127\.|0\.0\.0\.0|::1|fc|fd|fe80)/.test(h);}
 let _tmapGeoQueue=[],_tmapGeoRunning=0,_tmapGeoTimer=null;


### PR DESCRIPTION
## Summary

The Traffic Map's fallback target map (`_tmapSuiteHosts`) only had entries for **25 of the 55** test suites. For the other 30, when a log line lacked an extractable host (banners, ambient status messages, lines whose hostnames sit outside the regex patterns), no fallback was picked and no arc/feed entry was produced — leaving those suites invisible on the map.

## Coverage before vs. after

| | Suites covered |
|---|---|
| Before | icmp · dns · ips-ua · cve-probe · ids-sigs · log4shell · ntp · snmp · bgp · bulk-transfer · speedtest · web-scanner · blocklist-probe · phishing-domains · tls-inspection · lateral-movement · all 9 `msf-*` (25 total) |
| After  | All 55 — verified by diffing `_SUITE_MAP` keys against `_tmapSuiteColor` and `_tmapSuiteHosts` (55 == 55 == 55, zero missing or extra) |

## What was added

Canonical hostnames for the 30 missing suites, grouped by family:

- **HTTP / web**: http · https · http3 · web-crawl · ftp · ssh · post-quantum · url-latency · s3 · iperf3
- **DNS**: doh · dot · dns-exfil
- **Voice / video**: voip · ucaas
- **DLP / data-exfil**: dlp · data-exfil-http
- **AI / LLM**: ai-browse · llm-dlp
- **Threat / malware**: av-test · malware-samples · c2-beacon · c2-useragents · waf-attack · nmap
- **Categories**: ad-tracker · tor-anonymizer · shadow-it · pornography · squatting

Targets are pulled from each suite's actual endpoint list in `endpoints.py` (`stun_servers`, `sip_servers`, `ucaas_endpoints`, `doh_providers`, `dot_servers`, `data_exfil_targets`, `tor_anonymizer_endpoints`, `shadow_it_endpoints`, `virus_endpoints`, `dlp_https_endpoints`, `c2_beacon_targets`, etc.) or canonical public equivalents when the suite uses inline targets.

## Why fallbacks vs. fixing extraction

Most suites already log URLs/hostnames inline (http, https, web-crawl, pornography, ucaas, ai-browse, etc.) and rely on `_tmapExtractHost`'s regex patterns. The fallback only fires when extraction fails — covering banner lines, `_stats.block()` calls without a target, and edge-case log formats. So this PR is purely additive: no existing extraction path changes, no risk of regression on suites that already work.

## Test plan

- [ ] Run `traffgen --suite all --size S --loop` and verify every running suite contributes at least one arc and feed entry within a round.
- [ ] Run individual previously-invisible suites (`s3`, `iperf3`, `voip`, `tor-anonymizer`, `shadow-it`, `nmap`) and confirm they now appear in the feed.
- [ ] Confirm suites that already worked (http, https, pornography) still resolve their actual logged hostnames correctly — fallback should rarely fire for them.

https://claude.ai/code/session_01WY6BVw5wAdiq4kYz5LQ3kf

---
_Generated by [Claude Code](https://claude.ai/code/session_01WY6BVw5wAdiq4kYz5LQ3kf)_