### PR TITLE
fix(trafficmap): suppress fallback arcs for info-level lines without outcome

### DIFF
--- a/webui.py
+++ b/webui.py
@@ -5362,10 +5362,17 @@ function _tmapHandleLog(d){
     else _tmapLiveGeo(_tmapLastHost,suite,outcome);
     return;
   }
-  // Fallback: for suites whose logs lack extractable hosts, use suite's known targets
+  // Fallback: for suites whose logs lack extractable hosts, use suite's known
+  // targets — but only for *semantically meaningful* lines (those with a
+  // detected outcome, or warn/error level).  Plain info-level banner /
+  // progress lines without an outcome would otherwise repeatedly pick random
+  // fallback hosts and drown out the real activity in the feed.
   if(!host&&_tmapSuiteHosts[suite]){
-    const arr=_tmapSuiteHosts[suite];
-    host=arr[Math.floor(Math.random()*arr.length)];
+    const meaningful=outcome||(d.level&&d.level!=='info');
+    if(meaningful){
+      const arr=_tmapSuiteHosts[suite];
+      host=arr[Math.floor(Math.random()*arr.length)];
+    }
   }
   if(!host)return;
   const geo=_tmapGeo[host];


### PR DESCRIPTION
## Symptom

Web-crawl's Live Hit Feed showed the same handful of hostnames over and over (reddit.com, en.wikipedia.org, data.commoncrawl.org) even though the suite was actively crawling many other URLs.

## Root cause

The per-suite fallback added in #333 (`_tmapSuiteHosts`) was firing for **every** log line that lacked an extractable host — including ambient info-level lines like `Crawl attempt 1/10` or the suite banner. Each such line randomly picked a host from the suite's small fallback list and shot an arc / feed entry, swamping the real extracted-URL arcs which were still queued behind the `/api/geo` rate limit (40 calls/min to ip-api.com).

Result: the fallback (intended as a safety net for genuinely host-less events) became the dominant source of feed entries on high-throughput suites.

## Fix

In `_tmapHandleLog`, gate the fallback behind a "semantically meaningful" check:

```js
if(!host&&_tmapSuiteHosts[suite]){
  const meaningful = outcome || (d.level && d.level !== 'info');
  if(meaningful){
    const arr = _tmapSuiteHosts[suite];
    host = arr[Math.floor(Math.random()*arr.length)];
  }
}
```

The fallback now only fires when:
- An outcome was detected on the line (block/allowed regex matched), **or**
- The line is `warn`/`error` level (uncategorised but operationally significant).

Plain info-level banner / progress lines no longer trigger fallback arcs.

## What this does NOT change

- Real extracted hosts from log lines still shoot arcs (extraction path is untouched).
- Suites that were silent before #333 (blocks emitted via `_stats.block()` at `warn` level) still get fallback arcs because the level filter allows `warn`.
- The `_tmapSuiteHosts` map is unchanged — full 55-suite coverage from #333 is preserved.

## Test plan

- [ ] Run `traffgen --suite web-crawl --size M --loop` and verify the feed populates with the actual crawled URLs as they resolve through geo, not the same fallback set repeated.
- [ ] Run a block-heavy suite (`pornography`, `malware-samples`) and confirm BLOCKED entries still appear (they come through `warn`-level `_stats.block()` lines).
- [ ] Run silent-host suites (`icmp`, `dns`) and confirm they still display normally — they use direct extraction, not fallback.

https://claude.ai/code/session_01WY6BVw5wAdiq4kYz5LQ3kf

---
_Generated by [Claude Code](https://claude.ai/code/session_01WY6BVw5wAdiq4kYz5LQ3kf)_