### PR TITLE
fix: loop resilience, watchdog gaps, _size_to_limits crash, Pi 4 Docker repo

### DIFF
--- a/generator.py
+++ b/generator.py
@@ -1064,6 +1064,9 @@ def _run_guarded(func) -> None:
     can't block a clean exit.  Exceptions inside func() are caught and logged
     rather than propagating to the caller.
     """
+    # Kick here so the full watchdog budget is available for this test,
+    # regardless of how long the preceding inter-test pause was.
+    WATCHDOG.kick()
     limit = _SUITE_TIMEOUTS.get(func.__name__, 120)
     exc_box: list[BaseException] = []
     suite_name = _FUNC_TO_SUITE.get(func.__name__, func.__name__)
@@ -5016,7 +5019,7 @@ def ips_ua() -> None:
     reach a real victim host.  Validates that IDS/IPS / SASE platforms fire
     on User-Agent–based signatures (Snort/Suricata UA rules, ET category).
     """
-    n = _size_to_limits(ARGS.size, 10, 30, 60, len(ips_ua_signatures), len(ips_ua_signatures))
+    n = _size_to_limits(ARGS.size, 10, 30, 60, len(ips_ua_signatures))
     sample = random.sample(ips_ua_signatures, k=min(n, len(ips_ua_signatures)))
     target = random.choice(ips_ua_targets)
     url = f"http://{target}"
@@ -5077,7 +5080,7 @@ def cve_probe() -> None:
     Validates that network IPS / SASE inline inspection (Cato, Zscaler,
     Palo Alto, Fortinet) fires on CVE-specific HTTP patterns.
     """
-    n = _size_to_limits(ARGS.size, 5, 10, 20, len(cve_http_probes), len(cve_http_probes))
+    n = _size_to_limits(ARGS.size, 5, 10, 20, len(cve_http_probes))
     sample = random.sample(cve_http_probes, k=min(n, len(cve_http_probes)))
 
     ui_banner("CVE HTTP Probe",
@@ -5238,6 +5241,7 @@ def finish_test() -> None:
         _web_flush()
         _web_log("Tests paused — waiting for resume", level="info")
         while os.path.exists(_WEB_PAUSE_FILE):
+            WATCHDOG.kick()
             time.sleep(1)
         with _WEB_STATE_LOCK:
             _WEB_STATE["status"] = "between_tests"
@@ -5283,19 +5287,40 @@ def run_test(func_list: list) -> None:
             func = deck.pop()
             iteration += 1
             console.rule(f"[dim]iteration {iteration}[/]")
-            _run_guarded(func)
-            WATCHDOG.kick()
-            finish_test()
+            try:
+                _run_guarded(func)
+                WATCHDOG.kick()
+                finish_test()
+            except Exception as _loop_exc:
+                ui_error(f"[run_test] {func.__name__}: {_loop_exc!r} — continuing")
+                try:
+                    WATCHDOG.kick()
+                except Exception:
+                    pass
+            # Warn when abandoned threads accumulate (timed-out tests that are still
+            # running in the background can indicate resource pressure).
+            if iteration % 10 == 0:
+                _n_threads = threading.active_count()
+                if _n_threads > 30:
+                    ui_warn(f"[health] {_n_threads} threads alive — "
+                            "possible resource pressure from timed-out tests")
     else:
         _suite_stats.reset(ARGS.suite)
         random.shuffle(func_list)
         for func in func_list:
             iteration += 1
             console.rule(f"[dim]test {iteration}/{len(func_list)}[/]")
-            _run_guarded(func)
-            _suite_stats.merge(_stats)
-            WATCHDOG.kick()
-            finish_test()
+            try:
+                _run_guarded(func)
+                _suite_stats.merge(_stats)
+                WATCHDOG.kick()
+                finish_test()
+            except Exception as _loop_exc:
+                ui_error(f"[run_test] {func.__name__}: {_loop_exc!r} — continuing")
+                try:
+                    WATCHDOG.kick()
+                except Exception:
+                    pass
 
         # Print aggregate only when more than one function ran (avoids duplicate
         # of the per-function summary for single-function suites like 'dns').

--- a/stager.sh
+++ b/stager.sh
@@ -405,13 +405,13 @@ else
             brew install --cask docker
             ok "Docker Desktop installed — launching..."
             open -a Docker
-            step "Waiting for Docker Desktop to start (this may take up to 60 seconds)"
+            step "Waiting for Docker Desktop to start (this may take up to 120 seconds)"
             _tries=0
             until docker info &>/dev/null 2>&1; do
                 _tries=$((_tries + 1))
-                if [ "$_tries" -ge 30 ]; then
+                if [ "$_tries" -ge 60 ]; then
                     echo "" >&2
-                    echo "ERROR: Docker Desktop did not start within 60 seconds." >&2
+                    echo "ERROR: Docker Desktop did not start within 120 seconds." >&2
                     echo "       Open Docker Desktop from Applications and re-run this script." >&2
                     exit 1
                 fi
@@ -435,12 +435,12 @@ else
             # UBUNTU_CODENAME is the fallback for Mint/Pop!_OS which set it but not VERSION_CODENAME.
             CODENAME="${VERSION_CODENAME:-${UBUNTU_CODENAME:-}}"
 
-            if [ "${ID:-}" = "raspbian" ] && [ "$RPIVER" -ge 5 ]; then
+            if [ "${ID:-}" = "raspbian" ]; then
+                # Raspberry Pi OS (both 32-bit armhf and 64-bit arm64).
+                # The legacy download.docker.com/linux/raspbian repo was deprecated in 2023;
+                # use the Debian repo for all Pi models — it carries armhf and arm64 packages.
                 DOCKER_GPG="https://download.docker.com/linux/debian/gpg"
                 DOCKER_REPO="https://download.docker.com/linux/debian"
-            elif [ "${ID:-}" = "raspbian" ]; then
-                DOCKER_GPG="https://download.docker.com/linux/raspbian/gpg"
-                DOCKER_REPO="https://download.docker.com/linux/raspbian"
             elif is_like "ubuntu" || [ "${ID:-}" = "ubuntu" ]; then
                 DOCKER_GPG="https://download.docker.com/linux/ubuntu/gpg"
                 DOCKER_REPO="https://download.docker.com/linux/ubuntu"


### PR DESCRIPTION
## Summary

- **Critical crash**: `ips_ua` and `cve_probe` crashed on every invocation with `TypeError: _size_to_limits() takes 5 positional arguments but 6 were given` — found by running the tool live; fixed by dropping the spurious 6th positional argument from both call sites
- **Loop resilience**: Wrap each `run_test()` iteration in `try/except` so any orchestration-level exception logs and continues rather than propagating to `sys.exit(1)` and stopping all traffic generation
- **Watchdog false-fires**: Kick watchdog at the *start* of `_run_guarded()` (not just after it) so long `--max-wait-secs` values can't consume the 600 s window before the next test starts; also kick inside the UI pause loop so traffic paused >10 min doesn't trigger a spurious container restart
- **Thread health monitoring**: Warn every 10 iterations when >30 threads are alive (timed-out tests leaving background threads)
- **Pi 4 Raspbian broken**: `download.docker.com/linux/raspbian` was deprecated and removed in 2023 — caused 404-on-GPG-fetch + immediate `set -e` exit on any Pi 4 running Raspbian OS; replaced with the Debian repo for all Raspbian devices
- **macOS startup timeout**: Doubled Docker Desktop wait from 60 s → 120 s for M-series Macs which regularly take longer on first launch

## Test plan

- [x] `--suite=dns --size=XS --nowait` ran clean (10/10 allowed)
- [x] `--suite=cve-probe --size=XS --nowait` no longer crashes; produced 5 probes with accurate blocked/allowed split
- [x] `--suite=all --size=XS --loop --max-wait-secs=3` ran for 60 s; `ips_ua` and `cve_probe` no longer crash; loop resilience try/except visible catching the pre-fix crash and continuing
- [x] Verified `_size_to_limits` — no other call sites with too many positional args
- [x] Stager Raspbian repo fix confirmed against Docker's current repo structure

🤖 Generated with [Claude Code](https://claude.com/claude-code)