### PR TITLE
fix: Node.js 24 CI migration, HTTP 200 block-page detection, testmyids HTTPS (v3.10.1)

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   build-and-push:
     runs-on: ubuntu-latest
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
     steps:
       - name: Checkout

--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -19,6 +19,8 @@ jobs:
   check:
     name: Verify README reflects current code
     runs-on: ubuntu-latest
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/msf-base-publish.yml
+++ b/.github/workflows/msf-base-publish.yml
@@ -18,6 +18,8 @@ on:
 jobs:
   build-and-push:
     runs-on: ubuntu-latest
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
     steps:
       - name: Checkout

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ---
 
+## [3.10.1] — 2026-06-11
+
+### Fixed
+- **Block page accuracy** — HTTP 200 responses whose bodies contain vendor-agnostic block-page phrases (`Access Denied`, `Request Blocked`, `Policy Violation`, `threat prevention`, vendor names like `zscaler`, `fortigate`, `palo alto networks`, etc.) are now reclassified as `blocked` instead of `allowed`. Applies to all `requests`-based suite functions. Blocked-via-200 probes appear as `200bp` in the HTTP code breakdown. Curl-based probes (which discard the body with `-o /dev/null`) are unchanged.
+- **`c2_beacon_targets` — broken HTTPS entry** — removed `https://www.testmyids.com` (TLS certificate error: tlsv1 alert internal error). The HTTP entry `http://www.testmyids.com` is retained.
+- **CI — Node.js 24 migration** — added `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` to all three GitHub Actions workflows (`docker-publish.yml`, `msf-base-publish.yml`, `docs-check.yml`) ahead of GitHub's forced migration on 2026-06-16.
+
+---
+
 ## [3.10.0] — 2026-06-11
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [![Docker Hub](https://img.shields.io/docker/pulls/jdibby/traffgen?logo=docker&label=Docker%20Hub)](https://hub.docker.com/r/jdibby/traffgen)
 [![Multi-arch](https://img.shields.io/badge/arch-amd64%20%7C%20arm64%20%7C%20arm%2Fv7-blue?logo=linux)](https://hub.docker.com/r/jdibby/traffgen)
-[![Version](https://img.shields.io/badge/version-3.10.0-green)](https://github.com/jdibby/traffgen/blob/main/generator.py)
+[![Version](https://img.shields.io/badge/version-3.10.1-green)](https://github.com/jdibby/traffgen/blob/main/generator.py)
 
 Trafgen simulates realistic network traffic across **57 test suites** — DNS, HTTP/S, FTP, SSH, BGP, ICMP, NTP, SNMP, DoH, DoT, VoIP/UCaaS, C2 beacons, DNS exfiltration, AI/LLM DLP, lateral movement, TLS inspection checks, WAF attacks, crypto-mining, ransomware, iperf3 bandwidth, and more.
 

--- a/endpoints.py
+++ b/endpoints.py
@@ -4320,9 +4320,8 @@ dot_servers = [
 # them ideal for C2 detection rule validation without live infrastructure.
 # ---------------------------------------------------------------------------
 c2_beacon_targets = [
-    # Classic IDS trigger
+    # Classic IDS trigger (HTTP only — testmyids.com TLS cert is broken)
     "http://www.testmyids.com",
-    "https://www.testmyids.com",
 
     # httpbin — full request echo (POST body, headers, JSON visible to DLP/IDS)
     "https://httpbin.org/post",

--- a/generator.py
+++ b/generator.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 """
-generator.py — Traffic Generator v3.10.0
+generator.py — Traffic Generator v3.10.1
 ========================================
 Simulates realistic network traffic across a wide range of protocols and
 behaviours: DNS, HTTP/HTTPS/HTTP3, FTP, SSH, NTP, BGP, ICMP, SNMP,
@@ -58,7 +58,7 @@ from rich import box
 from endpoints import *           # noqa: F401,F403  (large data file)
 
 # ── Globals ───────────────────────────────────────────────────────────────────
-VERSION = "3.10.0"
+VERSION = "3.10.1"
 
 
 class _DualWriter:
@@ -338,6 +338,49 @@ _BLOCK_HTTP   = {"403", "407", "451", "511"}  # content filter / proxy auth / le
 _BLOCK_EXITS  = {5, 7, 35, 97}  # curl: proxy refused, conn refused/RST, SSL intercept, SOCKS refused
 _DROP_EXITS   = {6, 28}         # curl: DNS resolve failure (sinkhole), timeout (silent drop)
 
+# Vendor-agnostic phrases present in block-page bodies across all major NGFW,
+# SASE, and proxy platforms (Zscaler, Palo Alto, Fortinet, Cisco, Netskope,
+# Cato, Sophos, Symantec, F5, Squid, etc.).  When an HTTP 200 response body
+# contains any of these, the traffic was intercepted — not allowed.
+_BLOCK_PAGE_PATTERNS = {
+    "access denied",
+    "access blocked",
+    "request blocked",
+    "request denied",
+    "content blocked",
+    "this page is blocked",
+    "site blocked",
+    "url blocked",
+    "web blocked",
+    "blocked by",
+    "policy violation",
+    "security policy",
+    "threat prevention",
+    "malware blocked",
+    "phishing blocked",
+    "your connection has been blocked",
+    "this website has been blocked",
+    "internet access blocked",
+    "acceptable use policy",
+    "this site has been blocked",
+    "the requested url was rejected",
+    "transaction rejected",
+    "fortigate",            # Fortinet block page
+    "palo alto networks",   # PAN block page
+    "zscaler",              # Zscaler block page
+    "umbrella",             # Cisco Umbrella block page
+    "netskope",             # Netskope block page
+    "symantec web security", # Symantec proxy
+}
+
+
+def _is_block_page(body: str) -> bool:
+    """Return True if a 200 response body looks like an inline security block page."""
+    if not body:
+        return False
+    low = body[:4096].lower()  # only scan the first 4 KB — block pages are short
+    return any(pat in low for pat in _BLOCK_PAGE_PATTERNS)
+
 
 class SuiteStats:
     """Thread-safe per-suite probe counters with HTTP response-code tracking."""
@@ -362,9 +405,11 @@ class SuiteStats:
         self.probes: list[dict] = []  # per-probe details for drill-down
         self.start_time = time.time()
 
-    def record(self, code, exit_code: int = 0, target: str = "") -> None:
-        """Record an HTTP status code (and optional curl exit code).
-        '---' / '000' / '' counts as a drop/error."""
+    def record(self, code, exit_code: int = 0, target: str = "",
+               body: str = "") -> None:
+        """Record an HTTP status code (and optional curl exit code / response body).
+        '---' / '000' / '' counts as a drop/error.
+        HTTP 200 bodies matching _BLOCK_PAGE_PATTERNS are reclassified as blocked."""
         with self._lock:
             self.attempts += 1
             c = str(code).strip()
@@ -387,6 +432,12 @@ class SuiteStats:
                 self.responses += 1
                 bucket = (c[0] + "xx") if c[:1].isdigit() else c[:3]
                 self.codes[bucket] = self.codes.get(bucket, 0) + 1
+            elif c == "200" and body and _is_block_page(body):
+                # Inline block page — security control returned 200 with a deny body
+                outcome = "blocked"
+                self.blocked   += 1
+                self.responses += 1
+                self.codes["200bp"] = self.codes.get("200bp", 0) + 1
             else:
                 outcome = "allowed"
                 self.allowed   += 1
@@ -1304,7 +1355,7 @@ def bigfile() -> None:
             ) as resp:
                 if resp.status_code in (403, 429, 451):
                     ui_warn(f"HTTP {resp.status_code} from provider — skipping")
-                    _stats.record(str(resp.status_code))
+                    _stats.record(str(resp.status_code), body=resp.text)
                     continue
                 resp.raise_for_status()
                 total = int(resp.headers.get("content-length", 0))
@@ -2639,7 +2690,7 @@ def urlresponse_random() -> None:
                                      headers=_browser_headers_dict(_rt_ua))
                     t = r.elapsed.total_seconds()
                     console.log(f"({i}/{n}) {url}  {t:.3f}s")
-                    _stats.record(str(r.status_code))
+                    _stats.record(str(r.status_code), body=r.text)
                 except requests.exceptions.ConnectionError as e:
                     if "Connection refused" in str(e) or "ECONNREFUSED" in str(e) or "Reset" in str(e):
                         console.log(f"[yellow]skip (Connection refused)[/] {url}")
@@ -2752,7 +2803,7 @@ def s3_sim() -> None:
             )
             sc = str(resp.status_code)
             console.log(f"s3-get ({i}/{n_dl}) {url}  [{_status_style(sc)}]HTTP {sc}[/]")
-            _stats.record(sc)
+            _stats.record(sc, body=resp.text)
         except requests.exceptions.ConnectionError as e:
             console.log(f"[yellow]s3-get ({i}/{n_dl}) {url}  {e.__class__.__name__}[/]")
             if "Connection refused" in str(e) or "ECONNREFUSED" in str(e) or "Reset" in str(e):
@@ -2782,7 +2833,7 @@ def s3_sim() -> None:
             )
             sc = str(resp.status_code)
             console.log(f"s3-put ({i}/{n_ul}) {url}  [{_status_style(sc)}]HTTP {sc}[/]")
-            _stats.record(sc)
+            _stats.record(sc, body=resp.text)
         except requests.exceptions.ConnectionError as e:
             console.log(f"[yellow]s3-put ({i}/{n_ul}) {url}  {e.__class__.__name__}[/]")
             if "Connection refused" in str(e) or "ECONNREFUSED" in str(e) or "Reset" in str(e):
@@ -3223,7 +3274,7 @@ def c2_beacon() -> None:
                         verify=False,
                         allow_redirects=True,
                     )
-                    _stats.record(str(resp.status_code))
+                    _stats.record(str(resp.status_code), body=resp.text)
                 except requests.exceptions.ConnectionError as e:
                     if "Connection refused" in str(e) or "ECONNREFUSED" in str(e) or "Reset" in str(e):
                         console.log(f"[yellow]C2 ({i}/{beacons}) {target}  → Connection refused[/]")
@@ -3633,7 +3684,7 @@ def llm_dlp_sim() -> None:
                         f"  ↳ HTTP {resp.status_code} "
                         f"({'expected' if resp.status_code in (401, 403, 422) else 'check'})"
                     )
-                    _stats.record(str(resp.status_code))
+                    _stats.record(str(resp.status_code), body=resp.text)
                 except requests.exceptions.ConnectionError as e:
                     console.log("  ↳ unreachable (expected)")
                     if "Connection refused" in str(e) or "ECONNREFUSED" in str(e) or "Reset" in str(e):
@@ -3717,7 +3768,7 @@ def _probe_domain_list(local_path: str, n: int = 10) -> None:
                 r = requests.get(url, timeout=3, verify=False, allow_redirects=True,
                                  headers=_browser_headers_dict(_probe_ua))
                 console.log(f"({i}/{len(sample)}) {url}  →  {r.status_code}")
-                _stats.record(str(r.status_code))
+                _stats.record(str(r.status_code), body=r.text)
             except requests.exceptions.ConnectionError as e:
                 console.log(f"({i}/{len(sample)}) {url}  →  {e.__class__.__name__}")
                 if "Connection refused" in str(e) or "ECONNREFUSED" in str(e) or "Reset" in str(e):
@@ -3835,7 +3886,7 @@ def scrape_single_link(url: str) -> str | None:
         resp.raise_for_status()
         resp.encoding = resp.apparent_encoding or "utf-8"
         html = resp.text
-        _stats.record(str(resp.status_code))
+        _stats.record(str(resp.status_code), body=resp.text)
     except requests.exceptions.HTTPError as e:
         if e.response is not None:
             _stats.record(str(e.response.status_code))
@@ -4425,7 +4476,7 @@ def data_exfil_http() -> None:
                 verify=False,
                 allow_redirects=False,
             )
-            _stats.record(str(resp.status_code))
+            _stats.record(str(resp.status_code), body=resp.text)
             console.log(f"    ↳ [{_status_style(str(resp.status_code))}]HTTP {resp.status_code}[/]")
             ok_count += 1
         except requests.exceptions.ConnectionError as e:
@@ -4525,7 +4576,7 @@ def waf_attack() -> None:
                     resp = requests.post(url, data=body or {}, headers=headers,
                                          timeout=6, verify=False, allow_redirects=False)
                 status = str(resp.status_code)
-                _stats.record(status)
+                _stats.record(status, body=resp.text)
             console.log(f"    ↳ [{_status_style(status)}]HTTP {status}[/]")
             ok_count += 1
         except Exception as e:
@@ -5134,7 +5185,7 @@ def cve_probe() -> None:
                     allow_redirects=False,
                 )
                 status = str(resp.status_code)
-                _stats.record(status)
+                _stats.record(status, body=resp.text)
             console.log(f"    ↳ [{_status_style(status)}]HTTP {status}[/]")
             ok_count += 1
         except Exception as e:
@@ -5283,7 +5334,7 @@ def ransomware_sim() -> None:
                 verify=False,
                 allow_redirects=False,
             )
-            _stats.record(str(resp.status_code))
+            _stats.record(str(resp.status_code), body=resp.text)
             console.log(
                 f"    ↳ [{_status_style(str(resp.status_code))}]HTTP {resp.status_code}[/]"
             )

--- a/webui.py
+++ b/webui.py
@@ -2636,6 +2636,16 @@ docker run --pull=always -it jdibby/traffgen:latest --suite=dns --size=L</div>
       <div style="max-width:900px">
 
         <div class="a-section">
+          <div class="a-h">v3.10.1 &mdash; <span style="color:var(--muted);font-weight:400">Jun 2026</span></div>
+          <table class="st-table" style="margin-top:10px">
+            <tr><th style="width:80px">Type</th><th style="width:140px">Area</th><th>Description</th></tr>
+            <tr><td><span class="cl-fix">FIX</span></td><td>Outcomes</td><td><strong>HTTP 200 block-page detection</strong> — responses with status 200 whose bodies contain vendor-agnostic block-page phrases (Access Denied, Request Blocked, Policy Violation, threat prevention, zscaler, fortigate, palo alto networks, etc.) are now reclassified as <strong>blocked</strong> instead of allowed; appear as <code>200bp</code> in the HTTP code breakdown</td></tr>
+            <tr><td><span class="cl-fix">FIX</span></td><td>C2 Beacon</td><td><strong>Removed broken HTTPS testmyids.com entry</strong> — <code>https://www.testmyids.com</code> had a TLS certificate error (tlsv1 alert internal error); HTTP entry retained</td></tr>
+            <tr><td><span class="cl-fix">FIX</span></td><td>CI</td><td><strong>Node.js 24 migration</strong> — added <code>FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true</code> to all three GitHub Actions workflows ahead of GitHub's forced migration on 2026-06-16</td></tr>
+          </table>
+        </div>
+
+        <div class="a-section">
           <div class="a-h">v3.10.0 &mdash; <span style="color:var(--muted);font-weight:400">Jun 2026</span></div>
           <table class="st-table" style="margin-top:10px">
             <tr><th style="width:80px">Type</th><th style="width:140px">Area</th><th>Description</th></tr>


### PR DESCRIPTION
## Summary

- **CI — Node.js 24 migration** — added `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` env to all three workflows (`docker-publish.yml`, `msf-base-publish.yml`, `docs-check.yml`). GitHub forces Node 24 on 2026-06-16 (5 days); this opts in now and eliminates the deprecation warning.
- **Outcome accuracy — HTTP 200 block pages** — added `_BLOCK_PAGE_PATTERNS` (28 vendor-agnostic phrases: `access denied`, `request blocked`, `policy violation`, `zscaler`, `fortigate`, `palo alto networks`, `netskope`, `umbrella`, etc.) and `_is_block_page(body)` helper. `SuiteStats.record()` gains an optional `body=` parameter; HTTP 200 responses with matching bodies are reclassified as `blocked` and appear as `200bp` in the HTTP code breakdown. Wired into all `requests`-based call sites (~12 suite functions: `c2_beacon`, `ransomware_sim`, `https_random`, `https_crawl`, `shadow_it`, `waf_attack`, `cve_probe`, `s3_sim`, `url_latency`, and others).
- **`c2_beacon_targets`** — removed `https://www.testmyids.com` (TLS cert broken: tlsv1 alert internal error). The HTTP entry is retained.

## Test plan

- [x] `python3 -c "import generator"` — clean import
- [x] `_is_block_page()` unit test: detects zscaler/access-denied bodies, passes normal pages
- [x] `SuiteStats.record('200', body='<Access Denied...>')` → `blocked=1`, `codes['200bp']=1`
- [x] `SuiteStats.record('200', body='normal page')` → `allowed=1`
- [x] Docs accuracy check will verify v3.10.1 in webui.py changelog

🤖 Generated with [Claude Code](https://claude.com/claude-code)