### PR TITLE
fix: add anonymizer/VPN hosts to TLS auto-probe (32 -> 44 hosts)

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -73,17 +73,23 @@ fi
 # ── Option 3: auto-detect TLS interception across diverse probe hosts ──────────
 #
 # Strategy:
-#   1. Probe 32 hosts spanning different ASNs, providers, and URL categories:
+#   1. Probe 44 hosts spanning different ASNs, providers, and URL categories:
 #      14 cloud/developer-infra hosts (frequently exempted from inspection by
 #      policy — a clean result here alone is NOT proof of no interception),
 #      10 ordinary consumer-web hosts (news, commerce, reference,
 #      entertainment) that are rarely on any vendor's default bypass list and
 #      therefore give the real signal for whether traffgen's own traffic
 #      (which mostly looks like ordinary/adversarial web traffic, not cloud
-#      infra) is actually being inspected, and 8 AI/LLM hosts (ChatGPT,
-#      Claude, Gemini, Copilot, Perplexity, Character.AI, Hugging Face) since
-#      GenAI traffic is an active DLP/CASB inspection target for most SASE
-#      vendors but is often still bundled into a "trusted SaaS" bypass rule.
+#      infra) is actually being inspected, 8 AI/LLM hosts (ChatGPT, Claude,
+#      Gemini, Copilot, Perplexity, Character.AI, Hugging Face) since GenAI
+#      traffic is an active DLP/CASB inspection target for most SASE vendors
+#      but is often still bundled into a "trusted SaaS" bypass rule, and 12
+#      anonymizer/VPN/proxy-avoidance hosts (Tor, ProtonVPN, NordVPN,
+#      ExpressVPN, IPVanish, Mullvad, and public web proxies) — live testing
+#      against a real Cato Networks deployment showed this category gets
+#      TLS-inspected essentially unconditionally (unlike GenAI/cloud infra,
+#      which are frequently bypassed), making it the single most reliable
+#      probe category for confirming interception is active at all.
 #   2. For every host that fails TLS verification, extract CA certs from the
 #      presented chain and fingerprint them (SHA-256).
 #   3. Vote: a CA fingerprint seen on N > 1 hosts is almost certainly the proxy
@@ -137,6 +143,23 @@ auto_trust_proxy_ca() {
         "perplexity.ai:443"
         "character.ai:443"
         "huggingface.co:443"
+        # Anonymizers / VPN / proxy avoidance — empirically the most reliably
+        # inspected category (confirmed via live Cato dashboard events across
+        # dozens of requests): SASE/NGFW vendors treat this as a security-risk
+        # category, not a "trusted SaaS" bypass exemption, so a clean result
+        # here is a strong signal.
+        "www.torproject.org:443"
+        "check.torproject.org:443"
+        "www.protonvpn.com:443"
+        "nordvpn.com:443"
+        "www.expressvpn.com:443"
+        "www.ipvanish.com:443"
+        "mullvad.net:443"
+        "www.proxysite.com:443"
+        "www.croxyproxy.com:443"
+        "filterbypass.me:443"
+        "4everproxy.com:443"
+        "www.freeproxyserver.net:443"
     )
 
     local TMP_DIR


### PR DESCRIPTION
## Summary
- Adds 12 anonymizer/VPN/proxy hosts (Tor, ProtonVPN, NordVPN, ExpressVPN, IPVanish, Mullvad, proxysite.com, croxyproxy.com, filterbypass.me, 4everproxy.com, freeproxyserver.net) to `docker-entrypoint.sh`'s `auto_trust_proxy_ca()` probe set (32 → 44 hosts).
- Closes a real, live-confirmed gap in the v3.10.2 auto-probe fix (#359): that fix widened coverage to cloud-infra/consumer-web/AI-LLM hosts, but every one of those categories turned out to be routinely bypassed from inspection in practice (sanctioned-SaaS/GenAI exemptions), while the Anonymizers/VPN category is inspected essentially unconditionally by Cato (treated as a security-risk category, not a trusted-SaaS exemption).

## Why
Live testing against a real Cato Networks deployment (dozens of dashboard events over ~45 minutes) showed:
- `chatgpt.com`, `claude.ai`, and other GenAI/cloud-infra hosts: `TLS Inspection: 0` (bypassed), consistently.
- `torproject.org`, `protonvpn.com`, `nordvpn.com`, `ipvanish.com`, `mullvad.net`, `proxysite.com`, `croxyproxy.com`, `filterbypass.me`, `4everproxy.com`, `freeproxyserver.net`: `TLS Inspection: 1` (inspected) on every single request, across dozens of events, regardless of client fingerprint.

With only the old 32-host probe set, every reachable host in this environment was bypassed, so the probe would have reported "no interception detected" and skipped CA installation entirely — even though the proxy was actively inspecting other traffic.

## Test plan
- [x] `bash -n docker-entrypoint.sh` — syntax valid
- [x] `docker build` succeeds
- [x] Live run in this environment (actually behind Cato): probe correctly found 12/44 hosts intercepted (all from the new anonymizer category), 29 bypassed (cloud infra/consumer web/AI-LLM, confirming those really are exempted here), 3 unreachable
- [x] Vote-and-fingerprint logic correctly identified the real production CA: `O = Cato Networks Ltd., OU = Cato Cloud, CN = Cato Networks Root CA` (11/12 votes)
- [x] CA installed successfully via `update-ca-certificates`; verification pass confirmed previously-failed hosts (`one.one.one.one`, `torproject.org`, `check.torproject.org`) now validate

🤖 Generated with [Claude Code](https://claude.com/claude-code)