### PR TITLE
release: v3.12.0 — post-3.11.0 docs sync + trafficmap polish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ---
 
+## [3.12.0] — 2026-07-10
+
+### Added
+- **TLS-interception auto-probe — anonymizer/VPN category**: `auto_trust_proxy_ca()` in `docker-entrypoint.sh` gains a 12-host anonymizer/VPN/proxy-avoidance probe category (Tor, ProtonVPN, NordVPN, ExpressVPN, IPVanish, Mullvad, proxysite.com, croxyproxy.com, filterbypass.me, 4everproxy.com, freeproxyserver.net), bringing the probe set from 32 to 44 hosts. Live testing against a production Cato Networks deployment showed this category is inspected essentially unconditionally (a security-risk category, not a "trusted SaaS" bypass exemption) while cloud-infra/consumer-web/AI-LLM hosts are frequently bypassed — making it the most reliable single category for confirming interception is active at all.
+
+### Fixed
+- **`trafficmap` — Live Hit Feed duplicate entries**: a normal multi-line probe (URL line + result line) produced two feed rows for the same host — one neutral, one with the outcome badge. `_tmapAddFeed` now stores `host`/`suite`/`outcome` on the feed-item dataset and updates the most recent matching `(host, suite)` entry in place instead of inserting a duplicate.
+- **`trafficmap` — outcome regex false positives**: banner/info lines containing a bare 3-digit number (e.g. `"Tested 403 endpoints"`, `"Crawl seed (200/300)"`) were misclassified as blocked/allowed. HTTP status codes now only match with an explicit `HTTP `/`status:`/`code:` prefix or trailing ` OK`.
+- **`http3` — QUIC handshake stalls with no timeout**: `asyncio.wait_for(self._done.wait(), timeout=5.0)` in `head()` only bounded the wait for response headers — `quic_connect()` itself had no timeout, so a silently-dropped UDP/443 firewall rule stalled each probe for ~60 s (the OS socket timeout) instead of failing fast. The full `quic_connect()` + `head()` chain is now wrapped in a 10 s `asyncio.wait_for()`; blocked endpoints now report `timeout` in ~10 s.
+
+---
+
 ## [3.11.0] — 2026-07-10
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -4,13 +4,15 @@
 
 [![Docker Hub](https://img.shields.io/docker/pulls/jdibby/traffgen?logo=docker&label=Docker%20Hub)](https://hub.docker.com/r/jdibby/traffgen)
 [![Multi-arch](https://img.shields.io/badge/arch-amd64%20%7C%20arm64%20%7C%20arm%2Fv7-blue?logo=linux)](https://hub.docker.com/r/jdibby/traffgen)
-[![Version](https://img.shields.io/badge/version-3.11.0-green)](https://github.com/jdibby/traffgen/blob/main/generator.py)
+[![Version](https://img.shields.io/badge/version-3.12.0-green)](https://github.com/jdibby/traffgen/blob/main/generator.py)
 
 Trafgen simulates realistic network traffic across **57 test suites** — DNS, HTTP/S, FTP, SSH, BGP, ICMP, NTP, SNMP, DoH, DoT, VoIP/UCaaS, C2 beacons, DNS exfiltration, AI/LLM DLP, lateral movement, TLS inspection checks, WAF attacks, crypto-mining, ransomware, iperf3 bandwidth, and more.
 
 Purpose-built to validate **firewalls**, **IDS/IPS**, **URL filters**, **DLP engines**, **CASB platforms**, and **SIEM pipelines**.
 
 Runs as a Docker container with a built-in watchdog, per-test timeout guard, and healthcheck. Includes a live HTTPS monitoring dashboard on port 7777.
+
+Every HTTP(S)-probing suite can run through [curl-impersonate](https://github.com/lwthiker/curl-impersonate) (`--impersonate=chrome116`, `ff117`, `edge101`, `safari15-5`, and Linux variants) for browser-accurate TLS/HTTP2 fingerprints — defeating JA3-based SASE/NGFW client classifiers that flag Python `requests`/stock `curl` as non-browser traffic regardless of declared User-Agent.
 
 ---
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -185,7 +185,7 @@ When a TLS-inspection proxy (Cato Networks, Prisma Access, Palo Alto, Zscaler, N
 
 ### Option 3 — Fully automatic _(zero configuration)_
 
-Just run the container — no flags, no cert files. On startup the entrypoint probes **32 diverse HTTPS hosts** in parallel: 14 cloud/developer-infra hosts (CDN providers, cloud platforms, developer tooling, OS vendors, CA/PKI infrastructure), 10 ordinary consumer-web hosts (news, commerce, reference, entertainment), and 8 AI/LLM hosts (ChatGPT, Claude, Gemini, Copilot, Perplexity, Character.AI, Hugging Face). For every host that fails TLS verification the entrypoint:
+Just run the container — no flags, no cert files. On startup the entrypoint probes **44 diverse HTTPS hosts** in parallel: 14 cloud/developer-infra hosts (CDN providers, cloud platforms, developer tooling, OS vendors, CA/PKI infrastructure), 10 ordinary consumer-web hosts (news, commerce, reference, entertainment), 8 AI/LLM hosts (ChatGPT, Claude, Gemini, Copilot, Perplexity, Character.AI, Hugging Face), and 12 anonymizer/VPN/proxy-avoidance hosts (Tor, ProtonVPN, NordVPN, ExpressVPN, IPVanish, Mullvad, and public web proxies). For every host that fails TLS verification the entrypoint:
 
 1. Fetches the full certificate chain the proxy is presenting (`openssl s_client -showcerts`)
 2. Fingerprints (SHA-256) every `CA:TRUE` cert in the chain not yet in the system trust store
@@ -194,13 +194,13 @@ Just run the container — no flags, no cert files. On startup the entrypoint pr
 5. Runs a **verification pass** on a sample of previously-failed hosts to confirm the fix worked
 
 ```
-[entrypoint] Probing 32 hosts to detect TLS interception...
-[entrypoint] Results: 3 clean  28 intercepted  1 unreachable
+[entrypoint] Probing 44 hosts to detect TLS interception...
+[entrypoint] Results: 29 clean  12 intercepted  3 unreachable
 [entrypoint] Selective bypass detected:
-[entrypoint]   Bypassed (clean cert) : www.apple.com ocsp.pki.goog www.digicert.com
-[entrypoint]   Intercepted           : www.google.com www.cloudflare.com github.com ...
-[entrypoint] Proxy CA identified (seen on 28 of 28 intercepted host(s)):
-[entrypoint]   Subject    : CN=Cato Networks Root CA, O=Cato Networks, C=IL
+[entrypoint]   Bypassed (clean cert) : www.apple.com ocsp.pki.goog www.digicert.com ...
+[entrypoint]   Intercepted           : www.torproject.org www.protonvpn.com nordvpn.com ...
+[entrypoint] Proxy CA identified (seen on 11 of 12 intercepted host(s)):
+[entrypoint]   Subject    : CN=Cato Networks Root CA, OU=Cato Cloud, O=Cato Networks Ltd.
 [entrypoint]   Expires    : Dec 31 23:59:59 2035 GMT
 [entrypoint]   SHA-256 fp : 4A3B...
 [entrypoint] Installing proxy CA into trust store...
@@ -209,7 +209,7 @@ Just run the container — no flags, no cert files. On startup the entrypoint pr
 
 Set `DISABLE_AUTO_CA=1` to skip this step if you want to manage certs entirely yourself.
 
-**Known limitation:** many SASE/proxy vendors (Cato, Zscaler, Palo Alto Prisma, Netskope, etc.) ship default bypass rules that exempt cloud/developer infrastructure — Microsoft/Google/Apple domains, package registries, CA/OCSP endpoints — from inspection, and in practice this often extends to major consumer brands (news, streaming, retail) and even AI/LLM services (ChatGPT, Claude, Gemini, Copilot) as well, since those are frequently grouped into the same "trusted/reputable SaaS" bypass category. Because of this, the entrypoint probes cloud/dev infra, ordinary consumer-web hosts, and AI/LLM hosts (32 total), since a broader mix is much less likely to be uniformly bypassed. Even so, no fixed probe list can guarantee catching every proxy's bypass policy. If the auto-probe reports "no interception detected" (or only partial interception) but traffgen's own test suites (`tls-inspection`, or any HTTPS-based suite) still show TLS/certificate errors on other hosts, don't trust the clean result — your proxy is very likely bypassing every probed host by category while still inspecting other traffic. In that case, fall back to Option 1 or Option 2 below and install the proxy's CA directly.
+**Known limitation:** many SASE/proxy vendors (Cato, Zscaler, Palo Alto Prisma, Netskope, etc.) ship default bypass rules that exempt cloud/developer infrastructure — Microsoft/Google/Apple domains, package registries, CA/OCSP endpoints — from inspection, and in practice this often extends to major consumer brands (news, streaming, retail) and even AI/LLM services (ChatGPT, Claude, Gemini, Copilot) as well, since those are frequently grouped into the same "trusted/reputable SaaS" bypass category. The anonymizer/VPN category is the exception: live testing against a real Cato Networks deployment showed it inspected essentially unconditionally, since SASE/NGFW vendors treat it as a security-risk category rather than a trusted-SaaS exemption — making it the most reliable single category for confirming interception is active at all. Because of this, the entrypoint probes cloud/dev infra, ordinary consumer-web, AI/LLM, and anonymizer/VPN hosts (44 total), since a broader mix is much less likely to be uniformly bypassed. Even so, no fixed probe list can guarantee catching every proxy's bypass policy. If the auto-probe reports "no interception detected" (or only partial interception) but traffgen's own test suites (`tls-inspection`, or any HTTPS-based suite) still show TLS/certificate errors on other hosts, don't trust the clean result — your proxy is very likely bypassing every probed host by category while still inspecting other traffic. In that case, fall back to Option 1 or Option 2 below and install the proxy's CA directly.
 
 ### Option 1 — Bind-mount a certificate file
 

--- a/generator.py
+++ b/generator.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 """
-generator.py — Traffic Generator v3.11.0
+generator.py — Traffic Generator v3.12.0
 ========================================
 Simulates realistic network traffic across a wide range of protocols and
 behaviours: DNS, HTTP/HTTPS/HTTP3, FTP, SSH, NTP, BGP, ICMP, SNMP,
@@ -58,7 +58,7 @@ from rich import box
 from endpoints import *           # noqa: F401,F403  (large data file)
 
 # ── Globals ───────────────────────────────────────────────────────────────────
-VERSION = "3.11.0"
+VERSION = "3.12.0"
 
 
 class _DualWriter:

--- a/webui.py
+++ b/webui.py
@@ -1762,7 +1762,7 @@ select.diag-input{appearance:none;-webkit-appearance:none;background-color:var(-
 /* Widget grids: capped at 1400px, centered, full-height overflow-y */
 #ov-grid,#sec-grid,#health-grid{display:flex;flex-direction:column;gap:14px;max-width:1400px;width:100%;margin:0 auto}
 /* Max-width cap on other panel content (About, Tests, etc.) */
-.panel>*:not(#ov-grid):not(#sec-grid):not(#health-grid){max-width:1400px;width:100%;box-sizing:border-box;align-self:center}
+.panel>*:not(#ov-grid):not(#sec-grid):not(#health-grid):not(.tmap-main-row){max-width:1400px;width:100%;box-sizing:border-box;align-self:center}
 /* Stat cards: fully fluid, min 130px per card */
 .cards{display:grid;grid-template-columns:repeat(auto-fit,minmax(130px,1fr));gap:12px}
 .card{background:var(--surf);border:1px solid var(--border);border-radius:10px;padding:14px 16px;display:flex;flex-direction:column;gap:2px;transition:border-color .15s,box-shadow .15s;box-shadow:0 1px 4px rgba(0,0,0,.25)}
@@ -2636,6 +2636,17 @@ docker run --pull=always -it jdibby/traffgen:latest --suite=dns --size=L</div>
       <div style="max-width:900px">
 
         <div class="a-section">
+          <div class="a-h">v3.12.0 &mdash; <span style="color:var(--muted);font-weight:400">Jul 2026</span></div>
+          <table class="st-table" style="margin-top:10px">
+            <tr><th style="width:80px">Type</th><th style="width:140px">Area</th><th>Description</th></tr>
+            <tr><td><span class="cl-feat">FEAT</span></td><td>Entrypoint</td><td><strong>TLS auto-probe — anonymizer/VPN category</strong> — <code>auto_trust_proxy_ca()</code> gains 12 anonymizer/VPN/proxy-avoidance hosts (Tor, ProtonVPN, NordVPN, ExpressVPN, IPVanish, Mullvad, and public web proxies), bringing the probe set from 32 to 44 hosts. Live-confirmed against Cato Networks: this category is inspected essentially unconditionally, unlike cloud-infra/consumer-web/AI-LLM hosts which are frequently bypassed — the single most reliable category for confirming interception is active at all</td></tr>
+            <tr><td><span class="cl-fix">FIX</span></td><td>Trafficmap</td><td><strong>Live Hit Feed duplicate entries</strong> — a multi-line probe (URL line + result line) produced two feed rows for the same host; the feed now updates the most recent matching host/suite entry in place instead of inserting a duplicate</td></tr>
+            <tr><td><span class="cl-fix">FIX</span></td><td>Trafficmap</td><td><strong>Outcome regex false positives</strong> — banner lines containing a bare 3-digit number (e.g. "Tested 403 endpoints") were misclassified as blocked/allowed; status codes now require an explicit HTTP/status/code prefix or trailing " OK"</td></tr>
+            <tr><td><span class="cl-fix">FIX</span></td><td>http3</td><td><strong>QUIC handshake stalls with no timeout</strong> — the inner response-wait timeout didn't cover <code>quic_connect()</code> itself, so a silently-dropped UDP/443 firewall rule stalled each probe ~60s; the full connect+head chain is now wrapped in a 10s timeout</td></tr>
+          </table>
+        </div>
+
+        <div class="a-section">
           <div class="a-h">v3.11.0 &mdash; <span style="color:var(--muted);font-weight:400">Jul 2026</span></div>
           <table class="st-table" style="margin-top:10px">
             <tr><th style="width:80px">Type</th><th style="width:140px">Area</th><th>Description</th></tr>
@@ -3470,6 +3481,7 @@ const ST_CLS={running:'tp-running',between_tests:'tp-paused',paused:'tp-paused',
 const ST_LBL={running:'Running',between_tests:'Between Tests',paused:'Paused',stopped:'Stopped',starting:'Starting'};
 function apply(s){
   _lastState=s;
+  if(_tmap)_tmapUpdateStats();
   _trackRunHistory(s);
   if(s.suites&&s.suites.length&&!Object.keys(_SD).length){s.suites.forEach(su=>{_SD[su.name]=su.description||'';});}
   const ver=s.version||'—';
@@ -4797,9 +4809,11 @@ function exportResults(fmt){
     if($('lat-heatmap'))_renderHeatmap();
   },3000);
 })();
+let _resizeTmapTimer=null;
 window.addEventListener('resize',()=>{
   if(_lastState){drawSpark(_lastState.history||[]);drawSecTrend(_secHist);}
   if(_lastHealth){drawDiskBars(_lastHealth.disk_read_kbps||0,_lastHealth.disk_write_kbps||0);drawNetSpark('net-spark',_netHist);drawNetSpark('h-net-spark',_hNetHist);}
+  if(_tmap){clearTimeout(_resizeTmapTimer);_resizeTmapTimer=setTimeout(()=>{if(_tmap)_tmap.invalidateSize();},150);}
 });
 // -- Canvas hover tooltips --------------------------------------------------
 const _tt=document.createElement('div');_tt.className='tt';document.body.appendChild(_tt);
@@ -4887,6 +4901,7 @@ _initDrag('health-grid');
 // ── Traffic Map ────────────────────────────────────────────────────────────────
 let _tmap=null,_tmapEs=null,_tmapExpanded=false,_tmapSrc=null,_tmapSrcMarker=null,_tmapPlacedHosts=new Set();
 let _tmapArcs=0,_tmapTotal=0,_tmapBlocked=0,_tmapEps=new Set();
+let _tmapBlockedBaseline=null;
 let _tmapTileBase=null,_tmapTileLabels=null;
 function _tmapApplyTiles(){
   if(!_tmap)return;
@@ -5224,14 +5239,6 @@ function _tmapExtractHost(msg){
   if(m)return m[1];
   return null;
 }
-function _tmapBuildArc(from,to,n){
-  n=n||60;
-  const dLon=Math.abs(to[1]-from[1]);
-  const lift=dLon*.18+Math.abs(to[0]-from[0])*.08;
-  const midLat=(from[0]+to[0])/2+lift;
-  const midLng=(from[1]+to[1])/2;
-  return Array.from({length:n+1},function(_,i){var t=i/n;return[(1-t)*(1-t)*from[0]+2*(1-t)*t*midLat+t*t*to[0],(1-t)*(1-t)*from[1]+2*(1-t)*t*midLng+t*t*to[1]];});
-}
 function _tmapOutcome(msg){
   if(!msg)return'';
   // Unambiguous block keywords — match anywhere in the message.
@@ -5245,6 +5252,15 @@ function _tmapOutcome(msg){
   if(/(?:\bHTTP\b\s+|\bstatus:?\s*|\bcode:?\s*|↳.*?HTTP\s+)(2\d\d)\b/i.test(msg)||/\b2\d\d\s+OK\b/i.test(msg))return'allowed';
   return'';
 }
+function _tmapArcPos(from,to,t){
+  const dLon=Math.abs(to[1]-from[1]);
+  const lift=dLon*.18+Math.abs(to[0]-from[0])*.08;
+  const midLat=(from[0]+to[0])/2+lift;
+  const midLng=(from[1]+to[1])/2;
+  const mt=1-t;
+  return[mt*mt*from[0]+2*mt*t*midLat+t*t*to[0],mt*mt*from[1]+2*mt*t*midLng+t*t*to[1]];
+}
+function _tmapEaseOut(t){return 1-Math.pow(1-t,3);}
 function _tmapShootArc(geo,suite,host,outcome){
   if(!_tmap)return;
   const blocked=outcome==='blocked';
@@ -5260,31 +5276,66 @@ function _tmapShootArc(geo,suite,host,outcome){
     _tmapExpanded=true;
     _tmap.flyTo([30,0],2,{duration:2});
   }
-  const pts=_tmapBuildArc(from,to);
-  const glow=L.polyline([pts[0]],{color:c,weight:6,opacity:.15,interactive:false,smoothFactor:1}).addTo(_tmap);
-  const core=L.polyline([pts[0]],{color:c,weight:1.5,opacity:.7,interactive:false,smoothFactor:1}).addTo(_tmap);
-  const dot=L.circleMarker(pts[0],{radius:5,color:'#fff',fillColor:c,fillOpacity:1,weight:2,interactive:false}).addTo(_tmap);
-  let i=0;const TRAIL=14;
-  const ticker=setInterval(function(){
-    i++;
-    if(i>=pts.length){
-      clearInterval(ticker);
+  const p0=_tmapArcPos(from,to,0);
+  const glow=L.polyline([p0],{color:c,weight:6,opacity:.15,interactive:false,smoothFactor:1}).addTo(_tmap);
+  const core=L.polyline([p0],{color:c,weight:1.5,opacity:.7,interactive:false,smoothFactor:1}).addTo(_tmap);
+  const dot=L.circleMarker(p0,{radius:5,color:'#fff',fillColor:c,fillOpacity:1,weight:2,interactive:false}).addTo(_tmap);
+  const DURATION=2000;
+  const TRAIL_FRAC=0.22;
+  let startTs=null;
+  function frame(ts){
+    if(!_tmap)return;
+    if(startTs===null)startTs=ts;
+    const rawT=Math.min(1,(ts-startTs)/DURATION);
+    const t=_tmapEaseOut(rawT);
+    const head=_tmapArcPos(from,to,t);
+    dot.setLatLng(head);
+    const trailStartT=Math.max(0,t-TRAIL_FRAC);
+    const STEPS=16;
+    const tail=Array.from({length:STEPS+1},function(_,i){return _tmapArcPos(from,to,trailStartT+(t-trailStartT)*(i/STEPS));});
+    glow.setLatLngs(tail);core.setLatLngs(tail);
+    if(rawT>=1){
       _tmapArcs=Math.max(0,_tmapArcs-1);
       _tmapUpdateStats();
-      const burst=L.circleMarker(to,{radius:5,color:c,fillColor:c,fillOpacity:.9,weight:0,interactive:false}).addTo(_tmap);
-      let r=5,op=.9;
-      const bT=setInterval(function(){r+=3;op-=.07;if(op<=0){clearInterval(bT);_tmap.removeLayer(burst);}else burst.setStyle({radius:r,fillOpacity:op,opacity:op});},30);
-      let tOp=.7;
-      const fade=setInterval(function(){tOp-=.04;if(tOp<=0){clearInterval(fade);[glow,core,dot].forEach(function(l){_tmap.removeLayer(l);});}else{glow.setStyle({opacity:tOp*.2});core.setStyle({opacity:tOp});dot.setStyle({fillOpacity:tOp,opacity:tOp});}},40);
+      _tmapArcArrive(to,c,glow,core,dot);
       return;
     }
-    dot.setLatLng(pts[i]);
-    const tail=pts.slice(Math.max(0,i-TRAIL),i+1);
-    glow.setLatLngs(tail);core.setLatLngs(tail);
-  },35);
+    requestAnimationFrame(frame);
+  }
+  requestAnimationFrame(frame);
+}
+function _tmapArcArrive(to,c,glow,core,dot){
+  const burst=L.circleMarker(to,{radius:5,color:c,fillColor:c,fillOpacity:.9,weight:0,interactive:false}).addTo(_tmap);
+  const BURST_MS=600,FADE_MS=900;
+  let bStart=null;
+  function burstFrame(ts){
+    if(!_tmap){_tmap&&_tmap.removeLayer(burst);return;}
+    if(bStart===null)bStart=ts;
+    const bt=Math.min(1,(ts-bStart)/BURST_MS);
+    burst.setStyle({radius:5+bt*20,fillOpacity:.9*(1-bt),opacity:.9*(1-bt)});
+    if(bt<1)requestAnimationFrame(burstFrame);else _tmap.removeLayer(burst);
+  }
+  requestAnimationFrame(burstFrame);
+  let fStart=null;
+  function fadeFrame(ts){
+    if(!_tmap)return;
+    if(fStart===null)fStart=ts;
+    const ft=Math.min(1,(ts-fStart)/FADE_MS);
+    const op=.7*(1-ft);
+    glow.setStyle({opacity:op*.2});core.setStyle({opacity:op});dot.setStyle({fillOpacity:op,opacity:op});
+    if(ft<1)requestAnimationFrame(fadeFrame);else{[glow,core,dot].forEach(function(l){_tmap.removeLayer(l);});}
+  }
+  requestAnimationFrame(fadeFrame);
 }
 function _tmapUpdateStats(){
-  const a=_tmapArcs,t=_tmapTotal,b=_tmapBlocked,c=Object.keys(_tmapCtry).length,e=_tmapEps.size;
+  const a=_tmapArcs,t=_tmapTotal,c=Object.keys(_tmapCtry).length,e=_tmapEps.size;
+  let b=_tmapBlocked;
+  if(_lastState&&_lastState.totals){
+    const liveBlk=(_lastState.status==='running'&&_lastState.live)?(_lastState.live.blocked||0):0;
+    const serverBlk=(_lastState.totals.blocked||0)+liveBlk;
+    if(_tmapBlockedBaseline===null)_tmapBlockedBaseline=serverBlk;
+    b=Math.max(0,serverBlk-_tmapBlockedBaseline);
+  }
   [['tmap-s-arcs',a],['tmap-s-total',t],['tmap-s-blocked',b],['tmap-s-ctry',c],['tmap-s-ep',e]].forEach(function(p){var el=$(p[0]);if(el)el.textContent=p[1];});
 }
 function _tmapUpdateCountries(){


### PR DESCRIPTION
## Summary
- Bumps VERSION to 3.12.0 and adds a CHANGELOG entry covering the PRs merged since the v3.11.0 tag: curl-impersonate fingerprinting docs, anonymizer/VPN TLS auto-probe coverage (32→44 hosts), trafficmap bug-audit fixes, and the http3 QUIC timeout fix.
- Updates README.md and docs/deployment.md to match (host counts, curl-impersonate blurb, anonymizer/VPN reliability note).
- Adds the matching v3.12.0 entry to the webui changelog tab.
- Reworks the trafficmap arc-shooting animation from setInterval to requestAnimationFrame (eased motion, smoother burst/fade), debounces map resize, and syncs the "blocked" stat off server-reported totals instead of pure client-side counting.

## Test plan
- [ ] Confirm docs-check.yml passes (README/version references)
- [ ] Confirm Docker Hub multi-arch build succeeds after merge
- [ ] Manually eyeball trafficmap arc animation in the dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)