### PR TITLE
fix: correct probe-count accounting and isolate stats from timed-out suites

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ---
 
+## [3.14.0] — 2026-07-11
+
+### Fixed
+- **Dashboard — "Total Requests"/"Success Rate" were measuring suite runs, not requests**: `_web_record()` incremented `attempts` by a hardcoded `+1` per completed suite run instead of using the suite's real per-probe count (`SuiteStats.attempts`, already computed correctly but never passed through — the in-progress `live.attempts` snapshot had it right all along). A `--loop` run with hundreds of probes per suite would show "Total Requests: 42" meaning 42 suite runs, not 42 requests. Added a `requests` field carrying the true per-probe count through to both `tests[name]` and `totals`; the Overview headline and its Success Rate now use it (`allowed/requests`), while `attempts`/`ok`/`fail` keep their original, still-valid suite-run-count meaning (relabeled "Runs" in the Tests-tab table where they're shown next to it, to avoid the same ambiguity).
+- **Security tab — "Other" bucket in the outcome donut could never show anything**: it computed `attempts − (allowed+blocked+dropped)`, but `attempts` is the run counter above — always far smaller than the probe-outcome sum, so `Math.max(0, …)` clamped it to 0 in every realistic scenario. Now compares against the real `requests` total, so probes that got no outcome classification (e.g. a suite-level exception via `fail()`) actually surface.
+- **Security tab — signal-breakdown panel undercounted drops**: `SuiteStats.record()`'s two `dropped` branches (curl exit 6/28, and blank/`000`/`---` responses) incremented `dropped` but never wrote to `codes{}` — only the separate `.drop()` helper did. Since most suites route through `record()`, the "Block Signal Breakdown" panel showed far less than the real dropped total shown right above it. Both branches now populate `codes` (`exit6`/`exit28`/a new `noresp` bucket for blank responses).
+- **Generator — a timed-out suite's abandoned thread could bleed stats into the next suite**: `_run_guarded()` abandons (doesn't kill) a suite thread that exceeds its timeout; since all suites shared one global `SuiteStats` object, an orphaned thread still running in the background could keep calling `.block()`/`.drop()`/etc. after the *next* suite had already reset those counters for itself, corrupting its per-suite blocked/dropped breakdown. `SuiteStats` now tracks which thread is currently "active" (set atomically together with the counter reset via a new `reset_for_run()`), and every outcome-recording method checks it first — an orphan's calls become silent no-ops instead of landing in whichever suite happens to be current.
+
+---
+
 ## [3.13.0] — 2026-07-10
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [![Docker Hub](https://img.shields.io/docker/pulls/jdibby/traffgen?logo=docker&label=Docker%20Hub)](https://hub.docker.com/r/jdibby/traffgen)
 [![Multi-arch](https://img.shields.io/badge/arch-amd64%20%7C%20arm64%20%7C%20arm%2Fv7-blue?logo=linux)](https://hub.docker.com/r/jdibby/traffgen)
-[![Version](https://img.shields.io/badge/version-3.13.0-green)](https://github.com/jdibby/traffgen/blob/main/generator.py)
+[![Version](https://img.shields.io/badge/version-3.14.0-green)](https://github.com/jdibby/traffgen/blob/main/generator.py)
 
 Trafgen simulates realistic network traffic across **57 test suites** — DNS, HTTP/S, FTP, SSH, BGP, ICMP, NTP, SNMP, DoH, DoT, VoIP/UCaaS, C2 beacons, DNS exfiltration, AI/LLM DLP, lateral movement, TLS inspection checks, WAF attacks, crypto-mining, ransomware, iperf3 bandwidth, and more.
 

--- a/generator.py
+++ b/generator.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 """
-generator.py — Traffic Generator v3.13.0
+generator.py — Traffic Generator v3.14.0
 ========================================
 Simulates realistic network traffic across a wide range of protocols and
 behaviours: DNS, HTTP/HTTPS/HTTP3, FTP, SSH, NTP, BGP, ICMP, SNMP,
@@ -58,7 +58,7 @@ from rich import box
 from endpoints import *           # noqa: F401,F403  (large data file)
 
 # ── Globals ───────────────────────────────────────────────────────────────────
-VERSION = "3.13.0"
+VERSION = "3.14.0"
 
 
 class _DualWriter:
@@ -387,11 +387,38 @@ class SuiteStats:
 
     def __init__(self) -> None:
         self._lock = threading.Lock()
+        self._active_thread: "threading.Thread | None" = None
         self._reset("unknown")
 
     def reset(self, name: str) -> None:
         with self._lock:
             self._reset(name)
+
+    def set_active_thread(self, thread: "threading.Thread") -> None:
+        """Mark `thread` as the only thread whose outcomes get recorded.
+
+        _run_guarded() abandons (doesn't kill) a suite thread that exceeds its
+        timeout, so it can still be running when the next suite starts and
+        resets these counters. Every outcome-recording method below checks
+        this before mutating anything, so once the next suite calls this with
+        its own thread, the orphan's calls become silent no-ops instead of
+        bleeding into whichever suite happens to be current.
+        """
+        with self._lock:
+            self._active_thread = thread
+
+    def reset_for_run(self, name: str, thread: "threading.Thread") -> None:
+        """reset() + set_active_thread() in one lock acquisition.
+
+        Doing these separately would leave a brief window, after counters
+        are cleared but before the new thread is marked active, where a
+        still-running orphaned thread from the *previous* run — whose
+        identity still matches _active_thread at that point — could sneak an
+        outcome into the freshly-reset counters.
+        """
+        with self._lock:
+            self._reset(name)
+            self._active_thread = thread
 
     def _reset(self, name: str) -> None:
         self.name       = name
@@ -411,6 +438,8 @@ class SuiteStats:
         '---' / '000' / '' counts as a drop/error.
         HTTP 200 bodies matching _BLOCK_PAGE_PATTERNS are reclassified as blocked."""
         with self._lock:
+            if threading.current_thread() is not self._active_thread:
+                return
             self.attempts += 1
             c = str(code).strip()
             if exit_code in _BLOCK_EXITS:
@@ -422,10 +451,13 @@ class SuiteStats:
                 outcome = "dropped"
                 self.dropped += 1
                 self.errors  += 1   # keep errors count for backwards compat
+                bucket = f"exit{exit_code}"
+                self.codes[bucket] = self.codes.get(bucket, 0) + 1
             elif not c or c in ("---", "000", "0"):
                 outcome = "dropped"
                 self.dropped += 1
                 self.errors  += 1
+                self.codes["noresp"] = self.codes.get("noresp", 0) + 1
             elif c in _BLOCK_HTTP:
                 outcome = "blocked"
                 self.blocked += 1
@@ -450,6 +482,8 @@ class SuiteStats:
     def ok(self, target: str = "") -> None:
         """Record a successful non-HTTP probe (ping, dig, SSH reached, etc.)."""
         with self._lock:
+            if threading.current_thread() is not self._active_thread:
+                return
             self.attempts  += 1
             self.responses += 1
             self.allowed   += 1
@@ -459,6 +493,8 @@ class SuiteStats:
     def fail(self, target: str = "") -> None:
         """Record a failed probe (exception, timeout, unreachable)."""
         with self._lock:
+            if threading.current_thread() is not self._active_thread:
+                return
             self.attempts += 1
             self.errors   += 1
             if target and len(self.probes) < _PROBE_DETAIL_MAX:
@@ -467,6 +503,8 @@ class SuiteStats:
     def block(self, exit_code: int = 7, target: str = "") -> None:
         """Record an explicit non-HTTP block (RST, proxy refusal detected externally)."""
         with self._lock:
+            if threading.current_thread() is not self._active_thread:
+                return
             self.attempts += 1
             self.blocked  += 1
             bucket = f"exit{exit_code}"
@@ -486,6 +524,8 @@ class SuiteStats:
     def drop(self, exit_code: int = 28, target: str = "") -> None:
         """Record a silent drop (timeout, no route, DNS sinkhole)."""
         with self._lock:
+            if threading.current_thread() is not self._active_thread:
+                return
             self.attempts += 1
             self.dropped  += 1
             self.errors   += 1
@@ -625,7 +665,7 @@ _WEB_STATE: dict = {
     "pause_until": 0.0,     # epoch seconds when current inter-test pause ends (0 = not pausing)
     "test_started_at": 0.0,
     "tests": {}, "suites": [],
-    "totals": {"attempts": 0, "ok": 0, "fail": 0, "blocked": 0, "dropped": 0, "allowed": 0},
+    "totals": {"attempts": 0, "requests": 0, "ok": 0, "fail": 0, "blocked": 0, "dropped": 0, "allowed": 0},
     "history": [{"t": int(__import__("time").time()), "ok": 0, "fail": 0}], "events": [],
     "_history_last_t": 0.0,
 }
@@ -673,16 +713,25 @@ def _live_flush_worker() -> None:
 def _web_record(name: str, ok: bool, dur_ms: int,
                 responses: int = 0, codes: "dict | None" = None,
                 blocked: int = 0, dropped: int = 0, allowed: int = 0,
-                probe_detail: "list | None" = None) -> None:
-    """Record one completed test run into the web state and flush to disk."""
+                attempts: int = 0, probe_detail: "list | None" = None) -> None:
+    """Record one completed test run into the web state and flush to disk.
+
+    `attempts` here is the suite's real per-probe attempt count
+    (SuiteStats.attempts) and is stored as `requests` — distinct from this
+    dict's own `attempts` key, which counts completed suite *runs* (it
+    advances by exactly 1 per call, in lockstep with ok/fail). Conflating
+    the two used to make "Total Requests"/"Success Rate" in the dashboard
+    actually measure suite-run counts rather than request volume.
+    """
     with _WEB_STATE_LOCK:
         t = _WEB_STATE["tests"].setdefault(name, {
-            "attempts": 0, "ok": 0, "fail": 0, "responses": 0,
+            "attempts": 0, "ok": 0, "fail": 0, "responses": 0, "requests": 0,
             "last_run_at": 0, "last_ok": True,
             "last_dur_ms": 0, "avg_dur_ms": 0, "codes": {},
             "blocked": 0, "dropped": 0, "allowed": 0, "probes": [],
         })
         t["attempts"]   += 1
+        t["requests"]   += attempts
         t["responses"]  += responses
         t["blocked"]    += blocked
         t["dropped"]    += dropped
@@ -718,6 +767,7 @@ def _web_record(name: str, ok: bool, dur_ms: int,
 
         tot = _WEB_STATE["totals"]
         tot["attempts"] += 1
+        tot["requests"]  = tot.get("requests", 0) + attempts
         tot["blocked"]   = tot.get("blocked", 0) + blocked
         tot["dropped"]   = tot.get("dropped", 0) + dropped
         tot["allowed"]   = tot.get("allowed", 0) + allowed
@@ -1171,7 +1221,14 @@ def _run_guarded(func) -> None:
     exc_box: list[BaseException] = []
     suite_name = _FUNC_TO_SUITE.get(func.__name__, func.__name__)
 
-    _stats.reset(func.__name__)
+    def _wrapper() -> None:
+        try:
+            func()
+        except BaseException as e:  # noqa: BLE001
+            exc_box.append(e)
+
+    t = threading.Thread(target=_wrapper, daemon=True, name=func.__name__)
+    _stats.reset_for_run(func.__name__, t)
     with _WEB_STATE_LOCK:
         _WEB_STATE["current_test"]    = suite_name
         _WEB_STATE["test_started_at"] = time.time()
@@ -1180,13 +1237,6 @@ def _run_guarded(func) -> None:
     _web_log(f"Starting {suite_name}", level="info", test=suite_name)
     t0 = time.time()
 
-    def _wrapper() -> None:
-        try:
-            func()
-        except BaseException as e:  # noqa: BLE001
-            exc_box.append(e)
-
-    t = threading.Thread(target=_wrapper, daemon=True, name=func.__name__)
     t.start()
     t.join(timeout=limit)
     if t.is_alive():
@@ -1199,7 +1249,7 @@ def _run_guarded(func) -> None:
     run_ok = not exc_box and not t.is_alive()
     _web_record(suite_name, run_ok, dur_ms, _stats.responses, dict(_stats.codes),
                 blocked=_stats.blocked, dropped=_stats.dropped, allowed=_stats.allowed,
-                probe_detail=list(_stats.probes))
+                attempts=_stats.attempts, probe_detail=list(_stats.probes))
     _web_log(
         f"{suite_name}: {_stats.attempts} attempts, "
         f"{_stats.responses} ok, {_stats.errors} fail — {dur_ms}ms",

--- a/webui.py
+++ b/webui.py
@@ -2185,7 +2185,7 @@ body.ro-mode .ro-ctrl{opacity:.32;cursor:not-allowed}
                 <button onclick="exportResults('json')" title="Download results as JSON" style="padding:3px 11px;background:var(--surf2);border:1px solid var(--border2);border-radius:6px;color:var(--text);cursor:pointer;font-size:12px;font-weight:400;letter-spacing:0;text-transform:none">&#11123; JSON</button>
               </div>
             </div>
-            <table data-sort-tbody="tbl-body"><thead><tr><th></th><th>Test</th><th class="r">Attempts</th><th class="r">OK</th><th class="r">Fail</th><th class="r">Rate</th><th class="r">Avg</th><th class="r">Last Run</th></tr></thead>
+            <table data-sort-tbody="tbl-body"><thead><tr><th></th><th>Test</th><th class="r" title="Completed suite runs (not individual requests)">Runs</th><th class="r">OK</th><th class="r">Fail</th><th class="r">Rate</th><th class="r">Avg</th><th class="r">Last Run</th></tr></thead>
             <tbody id="tbl-body"><tr><td colspan="8" class="empty">Waiting for data&#8230;</td></tr></tbody></table>
           </div>
           <div class="ecard" data-widget="live-events">
@@ -2721,6 +2721,17 @@ docker run --pull=always -it jdibby/traffgen:latest --suite=dns --size=L</div>
     <div id="tab-changelog" class="panel">
       <div style="max-width:900px">
         <input id="changelog-search" type="text" placeholder="&#128269; Search changelog&#8230;" oninput="_onChangelogSearch(this.value)" autocomplete="off" spellcheck="false" style="width:100%;max-width:320px;background:var(--surf2);border:1px solid var(--border2);border-radius:8px;padding:7px 12px;color:var(--text);font-size:14px;font-family:inherit;outline:none;margin-bottom:14px">
+
+        <div class="a-section">
+          <div class="a-h">v3.14.0 &mdash; <span style="color:var(--muted);font-weight:400">Jul 2026</span></div>
+          <table class="st-table" style="margin-top:10px">
+            <tr><th style="width:80px">Type</th><th style="width:140px">Area</th><th>Description</th></tr>
+            <tr><td><span class="cl-fix">FIX</span></td><td>Dashboard</td><td><strong>"Total Requests"/"Success Rate" were measuring suite runs, not requests</strong> — the server was incrementing "attempts" once per completed suite run instead of using the real per-probe count it already tracked internally. Added a <code>requests</code> field carrying the true probe count through; the Overview headline and Success Rate now use it, while the run-counter keeps its original meaning (relabeled "Runs" in the Tests tab)</td></tr>
+            <tr><td><span class="cl-fix">FIX</span></td><td>Security</td><td><strong>"Other" bucket in the outcome donut could never show anything</strong> — it compared the suite-run counter against the probe-outcome sum, which clamped to 0 in every realistic scenario; now compares against the real request total, so unclassified probes actually surface</td></tr>
+            <tr><td><span class="cl-fix">FIX</span></td><td>Security</td><td><strong>Signal-breakdown panel undercounted drops</strong> — the two most common "dropped" code paths never wrote to the per-code breakdown, only a rarer explicit-drop path did; both now populate it (including a new "No response" bucket for blank/timeout responses)</td></tr>
+            <tr><td><span class="cl-fix">FIX</span></td><td>Generator</td><td><strong>A timed-out suite's abandoned thread could bleed stats into the next suite</strong> — suites share one global stats object, and a suite thread abandoned after a timeout could keep writing block/drop outcomes into whichever suite runs next. Stats now track which thread is currently active and silently ignore outcomes from any other</td></tr>
+          </table>
+        </div>
 
         <div class="a-section">
           <div class="a-h">v3.13.0 &mdash; <span style="color:var(--muted);font-weight:400">Jul 2026</span></div>
@@ -3635,10 +3646,16 @@ function apply(s){
   const lp=$('pill-live');if(isStopped){lp.className='tp-pill tp-stopped';lp.innerHTML='&#9654; RESTART';lp.title='Click to restart tests';}else{lp.className='tp-pill tp-running';lp.innerHTML='<span class="pulse"></span>LIVE';lp.title='Click to stop all tests';}
   $('cfg-s-pill').textContent='suite:'+(s.suite||'—');$('cfg-z-pill').textContent='size:'+(s.size||'—');
   const live=st==='running'&&s.live?s.live:null;
-  const tot=s.totals||{},ok=tot.ok||0,fail=tot.fail||0,att=tot.attempts||0,p=att?ok/att*100:0,blk=tot.blocked||0,drp=tot.dropped||0;
-  $('v-total').textContent=N(att);
-  {const livePart=live?' \xb7 ↻ '+N(live.attempts)+' req in progress':'';$('s-total').textContent=N(ok)+' ok \xb7 '+N(fail)+' fail'+(blk?' \xb7 '+N(blk)+' blocked':'')+(drp?' \xb7 '+N(drp)+' dropped':'')+livePart;}
-  $('v-rate').textContent=att?p.toFixed(1)+'%':'—';$('v-rate').style.color=att?RC(p):'var(--muted)';$('s-rate').textContent=att?N(att)+' total requests':'No data yet';
+  // "requests"/"allowed"/"blocked"/"dropped" are real per-probe counts; "attempts"/"ok"/"fail"
+  // are a separate, coarser per-suite-*run* counter (advances by 1 per completed suite,
+  // regardless of how many probes it made) — kept distinct so neither metric gets diluted
+  // by the other's unit.
+  const tot=s.totals||{},ok=tot.ok||0,fail=tot.fail||0,blk=(tot.blocked||0)+(live?live.blocked||0:0),drp=(tot.dropped||0)+(live?live.dropped||0:0);
+  const req=(tot.requests||0)+(live?live.attempts||0:0),allowedTot=(tot.allowed||0)+(live?live.allowed||0:0);
+  const p=req?allowedTot/req*100:0;
+  $('v-total').textContent=N(req);
+  {const livePart=live?' \xb7 ↻ '+N(live.attempts)+' req in progress':'';$('s-total').textContent=N(ok)+' runs ok \xb7 '+N(fail)+' runs failed'+(blk?' \xb7 '+N(blk)+' blocked':'')+(drp?' \xb7 '+N(drp)+' dropped':'')+livePart;}
+  $('v-rate').textContent=req?p.toFixed(1)+'%':'—';$('v-rate').style.color=req?RC(p):'var(--muted)';$('s-rate').textContent=req?N(req)+' total requests':'No data yet';
   const cur=s.current_test||'',tsa=s.test_started_at||0;
   $('v-test').textContent=cur?cur:'—';
   const tbt=$('tb-test'),tbn=$('tb-test-name'),tbi=$('tb-test-ico');
@@ -3678,6 +3695,7 @@ function apply(s){
     <tr class="xrow${exp?' open':''}"><td class="xcell" colspan="8"><div class="xinner">
       <div class="xi"><div class="xl">Last Dur</div>${t.last_dur_ms?Dur(t.last_dur_ms):'—'}</div>
       <div class="xi"><div class="xl">Avg Dur</div>${t.avg_dur_ms?Dur(t.avg_dur_ms):'—'}</div>
+      <div class="xi"><div class="xl">Requests</div>${N(t.requests||0)}</div>
       <div class="xi"><div class="xl">Responses</div>${N(t.responses||0)}</div>
       <div class="xi"><div class="xl">HTTP Codes</div><div class="ctags">${ctags||'<span style="color:var(--dim)">none yet</span>'}</div></div>
       <div class="xi"><div class="xl">Blocked</div>${N(t.blocked||0)}</div>
@@ -4315,12 +4333,18 @@ function updateSecurityTab(){
   const _live=_lastState.status==='running'&&_lastState.live?_lastState.live:null;
   const blk=(tot.blocked||0)+(_live?_live.blocked||0:0),drp=(tot.dropped||0)+(_live?_live.dropped||0:0),rch=(tot.allowed||0)+(_live?_live.allowed||0:0);
   const totalProbes=rch+blk+drp;
-  const other=Math.max(0,(tot.attempts||0)-totalProbes);
+  // reqTotal is the true per-probe attempt count (see apply()); comparing it
+  // against totalProbes (allowed+blocked+dropped) surfaces probes that never
+  // got an outcome classification — e.g. a suite-level exception via fail().
+  // (tot.attempts, the suite-*run* counter, is unrelated and far smaller —
+  // comparing against that made this always clamp to 0.)
+  const reqTotal=(tot.requests||0)+(_live?_live.attempts||0:0);
+  const other=Math.max(0,reqTotal-totalProbes);
   const pct=(n,d)=>d?((n/d)*100).toFixed(1)+'%':'—';
-  $('sec-total').textContent=N(totalProbes);$('sec-total-sub').textContent=totalProbes?'total probes':'No data yet';
-  $('sec-blocked').textContent=N(blk);$('sec-blocked-sub').textContent=totalProbes?pct(blk,totalProbes)+' of probes':'—';
-  $('sec-dropped').textContent=N(drp);$('sec-dropped-sub').textContent=totalProbes?pct(drp,totalProbes)+' of probes':'—';
-  $('sec-allowed').textContent=N(rch);$('sec-allowed-sub').textContent=totalProbes?pct(rch,totalProbes)+' of probes':'—';
+  $('sec-total').textContent=N(reqTotal);$('sec-total-sub').textContent=reqTotal?'total probes':'No data yet';
+  $('sec-blocked').textContent=N(blk);$('sec-blocked-sub').textContent=reqTotal?pct(blk,reqTotal)+' of probes':'—';
+  $('sec-dropped').textContent=N(drp);$('sec-dropped-sub').textContent=reqTotal?pct(drp,reqTotal)+' of probes':'—';
+  $('sec-allowed').textContent=N(rch);$('sec-allowed-sub').textContent=reqTotal?pct(rch,reqTotal)+' of probes':'—';
   $('sec-leg-allowed').textContent=N(rch)+' Allowed';
   $('sec-leg-blocked').textContent=N(blk)+' Blocked';
   $('sec-leg-dropped').textContent=N(drp)+' Dropped';
@@ -4329,7 +4353,7 @@ function updateSecurityTab(){
   // snapshot for trend (rate-limited to configured interval)
   const now=Date.now()/1000;
   if(!_secHist.length||now-_secHist[_secHist.length-1].t>=(_secInterval/1000)-1){
-    _secHist.push({t:now,block_pct:totalProbes?blk/totalProbes*100:0,drop_pct:totalProbes?drp/totalProbes*100:0,reach_pct:totalProbes?rch/totalProbes*100:0});
+    _secHist.push({t:now,block_pct:reqTotal?blk/reqTotal*100:0,drop_pct:reqTotal?drp/reqTotal*100:0,reach_pct:reqTotal?rch/reqTotal*100:0});
     if(_secHist.length>120)_secHist.shift();
   }
   drawSecTrend(_secHist);
@@ -4371,13 +4395,13 @@ function updateSecurityTab(){
     '4xx':'HTTP 4xx','exit7':'TCP RST (firewall block)','exit5':'Proxy refused',
     'exit35':'TLS intercept','exit97':'SOCKS refused','exit6':'DNS sinkhole',
     'exit28':'Timeout (silent drop)','2xx':'HTTP 2xx (allowed)','3xx':'HTTP 3xx (redirect)',
-    '5xx':'HTTP 5xx (server error)',
+    '5xx':'HTTP 5xx (server error)','noresp':'No response (blank/timeout)',
   };
   const sigEl=$('sec-signals');
   const entries=Object.entries(codeTotals).filter(([,v])=>v>0).sort((a,b)=>b[1]-a[1]);
   if(!entries.length){sigEl.innerHTML='<div class="empty">No data yet</div>';return;}
   const blockCodes=new Set(['4xx','exit7','exit5','exit35','exit97']);
-  const dropCodes=new Set(['exit6','exit28']);
+  const dropCodes=new Set(['exit6','exit28','noresp']);
   sigEl.innerHTML=entries.map(([k,v])=>{
     const lbl=signalDefs[k]||k;
     const col=blockCodes.has(k)?'var(--amber)':dropCodes.has(k)?'#818cf8':k.startsWith('2')?'#22c55e':'var(--muted)';
@@ -4839,14 +4863,14 @@ document.addEventListener('DOMContentLoaded',_renderRunHistory);
 function exportResults(fmt){
   if(!_lastState){toast('No data to export yet',false);return;}
   const tests=_lastState.tests||{},tot=_lastState.totals||{};
-  const rows=Object.keys(tests).sort().map(n=>{const t=tests[n];return{suite:n,attempts:t.attempts||0,ok:t.ok||0,fail:t.fail||0,allowed:t.allowed||0,blocked:t.blocked||0,dropped:t.dropped||0};});
+  const rows=Object.keys(tests).sort().map(n=>{const t=tests[n];return{suite:n,runs:t.attempts||0,requests:t.requests||0,ok:t.ok||0,fail:t.fail||0,allowed:t.allowed||0,blocked:t.blocked||0,dropped:t.dropped||0};});
   let content,mime,ext;
   if(fmt==='json'){
     const payload={exported_at:new Date().toISOString(),status:_lastState.status||'',totals:tot,suites:rows};
     content=JSON.stringify(payload,null,2);mime='application/json';ext='json';
   } else {
-    const hdr='suite,attempts,ok,fail,allowed,blocked,dropped\\n';
-    content=hdr+rows.map(r=>[r.suite,r.attempts,r.ok,r.fail,r.allowed,r.blocked,r.dropped].join(',')).join('\\n');
+    const hdr='suite,runs,requests,ok,fail,allowed,blocked,dropped\\n';
+    content=hdr+rows.map(r=>[r.suite,r.runs,r.requests,r.ok,r.fail,r.allowed,r.blocked,r.dropped].join(',')).join('\\n');
     mime='text/csv';ext='csv';
   }
   _download(content,mime,'traffgen-results-'+new Date().toISOString().slice(0,19).replace(/[T:]/g,'-')+'.'+ext);
@@ -4854,7 +4878,7 @@ function exportResults(fmt){
 function exportSecurity(fmt){
   if(!_lastState){toast('No data to export yet',false);return;}
   const tests=_lastState.tests||{};
-  const rows=Object.keys(tests).sort().map(n=>{const t=tests[n];const rch=t.allowed||0,blk=t.blocked||0,drp=t.dropped||0,tot=rch+blk+drp;return{suite:n,probes:tot,allowed:rch,blocked:blk,dropped:drp,block_pct:tot?+(blk/tot*100).toFixed(1):0,drop_pct:tot?+(drp/tot*100).toFixed(1):0};});
+  const rows=Object.keys(tests).sort().map(n=>{const t=tests[n];const rch=t.allowed||0,blk=t.blocked||0,drp=t.dropped||0,probeTotal=t.requests||(rch+blk+drp);return{suite:n,probes:probeTotal,allowed:rch,blocked:blk,dropped:drp,block_pct:probeTotal?+(blk/probeTotal*100).toFixed(1):0,drop_pct:probeTotal?+(drp/probeTotal*100).toFixed(1):0};});
   let content,mime,ext;
   if(fmt==='json'){
     content=JSON.stringify({exported_at:new Date().toISOString(),totals:_lastState.totals||{},suites:rows},null,2);mime='application/json';ext='json';


### PR DESCRIPTION
## Summary
Audited how blocked/dropped/allowed get calculated in the dashboard end-to-end. Found and fixed:

- **"Total Requests"/"Success Rate" were measuring suite runs, not requests.** `_web_record()` incremented `attempts` by a hardcoded `+1` per completed suite run instead of the real per-probe count `SuiteStats` already tracked (the live in-progress snapshot had this right all along — only the post-completion path discarded it). Added a `requests` field carrying the true count through; Overview headline + Success Rate now use it. `attempts`/`ok`/`fail` keep their original suite-run-count meaning, relabeled "Runs" where shown next to it in the Tests tab.
- **Security tab's "Other" bucket could never show anything.** It compared the run counter against the probe-outcome sum — always far smaller, so it clamped to 0 every time. Now compares against the real request total.
- **Signal-breakdown panel undercounted drops.** The two most common `dropped` code paths in `record()` never wrote to the per-code breakdown; only a rarer explicit `.drop()` path did. Both now populate it (plus a new "No response" bucket for blank/timeout responses).
- **A timed-out suite's abandoned thread could bleed stats into the next suite.** All suites share one global `SuiteStats` object; `_run_guarded()` abandons (doesn't kill) a thread that exceeds its timeout, and that orphan could keep writing block/drop outcomes into whichever suite runs next. `SuiteStats` now tracks which thread is currently active (set atomically with the counter reset) and every outcome-recording method silently ignores calls from any other thread.

## Test plan
- [x] Standalone Python unit test for the thread-isolation logic: normal accounting, `codes{}` population on both dropped paths, and a simulated orphaned-writer-thread racing a fresh suite's reset — confirms zero bleed
- [x] Verified against a running instance (headless Chromium) with synthetic state where `requests` (850) ≫ `attempts` (12): Total Requests, Success Rate, Security tab's Total/Blocked/Dropped/Allowed/Other, the donut chart, the signal-breakdown panel, and the Tests-tab "Runs" header + new "Requests" detail row all show mathematically correct numbers
- [ ] Confirm docs-check.yml passes
- [ ] Confirm Docker Hub build succeeds after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)